### PR TITLE
Make setup wizard URL examples click-to-copy

### DIFF
--- a/src/vibe_quality_searcharr/templates/setup/instance.html
+++ b/src/vibe_quality_searcharr/templates/setup/instance.html
@@ -55,11 +55,11 @@
                             required
                             placeholder="http://localhost:8989"
                             value="{{ url or '' }}">
-                        <small>Full URL including port (e.g., http://localhost:8989 or http://192.168.1.100:7878)</small>
+                        <small>Full URL including port (e.g., <code class="copy-url" title="Click to copy">http://localhost:8989</code> or <code class="copy-url" title="Click to copy">http://192.168.1.100:7878</code>)</small>
                     </label>
                     <div class="alert alert-info" style="margin-top: 0.75rem; font-size: 0.875rem;">
                         <strong>Docker Networking Tip:</strong> If <code>localhost</code> or your machine's IP
-                        doesn't work inside Docker, try <code>http://host.docker.internal:8989</code> instead.
+                        doesn't work inside Docker, try <code class="copy-url" title="Click to copy">http://host.docker.internal:8989</code> instead.
                     </div>
                 </div>
 
@@ -166,5 +166,23 @@ async function testConnection() {
 }
 
 document.getElementById('testConnectionBtn').addEventListener('click', testConnection);
+
+// Click-to-copy for example URLs
+document.querySelectorAll('.copy-url').forEach(function(el) {
+    el.style.cursor = 'pointer';
+    el.style.borderBottom = '1px dashed var(--brand-info)';
+    el.addEventListener('click', function() {
+        var text = this.textContent;
+        navigator.clipboard.writeText(text).then(function() {
+            var orig = el.textContent;
+            el.textContent = 'Copied!';
+            el.style.color = 'var(--brand-success)';
+            setTimeout(function() {
+                el.textContent = orig;
+                el.style.color = '';
+            }, 1200);
+        });
+    });
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Example URLs in the instance setup page are now clickable `<code>` snippets
- Clicking copies the URL to clipboard with a brief green "Copied!" feedback that reverts after 1.2s
- Applies to all three examples: `http://localhost:8989`, `http://192.168.1.100:7878`, and `http://host.docker.internal:8989`

## Test plan
- [ ] Go through setup wizard to the Instance page
- [ ] Click each example URL — should show "Copied!" briefly in green
- [ ] Paste from clipboard — should contain the clicked URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)