### PR TITLE
security: harden CSP, headers, SSRF validation, and config

### DIFF
--- a/src/vibe_quality_searcharr/api/dashboard.py
+++ b/src/vibe_quality_searcharr/api/dashboard.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta
 from typing import Annotated, Any
 
 import structlog
-from fastapi import APIRouter, Cookie, Depends, Form, Request, Response, status
+from fastapi import APIRouter, Cookie, Depends, Form, Query, Request, Response, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.exc import IntegrityError
@@ -890,7 +890,7 @@ async def api_dashboard_stats(
 
 @router.get("/api/dashboard/activity", include_in_schema=False)
 async def api_dashboard_activity(
-    limit: int = 10,
+    limit: int = Query(10, ge=1, le=100),
     current_user: User = Depends(get_current_user_from_cookie),
     db: Session = Depends(get_db),
 ) -> JSONResponse:

--- a/src/vibe_quality_searcharr/config.py
+++ b/src/vibe_quality_searcharr/config.py
@@ -349,6 +349,14 @@ class Settings(BaseSettings):
         # Fall back to environment variable
         return env_value
 
+    @field_validator("algorithm")
+    @classmethod
+    def validate_algorithm(cls, v: str) -> str:
+        """Constrain JWT algorithm to HS256 to prevent algorithm confusion attacks."""
+        if v != "HS256":
+            raise ValueError(f"Invalid JWT algorithm: {v}. Only 'HS256' is allowed.")
+        return v
+
     @field_validator("environment")
     @classmethod
     def validate_environment(cls, v: str) -> str:


### PR DESCRIPTION
## Summary

6 security fixes for headers, CSP, SSRF, and configuration:

1. **Add `object-src 'none'` to CSP (Medium)** — Blocks `<object>`/`<embed>` plugin-based XSS vectors
2. **Add `Permissions-Policy` header (Medium)** — Explicitly denies camera, microphone, geolocation, payment APIs
3. **Remove deprecated `X-XSS-Protection` header (Low)** — Deprecated in all modern browsers, can cause issues. Nonce-based CSP is the correct replacement.
4. **Fix `expose_headers: ["*"]` in CORS (Medium)** — Changed to `[]`. Was exposing all response headers to cross-origin JS unnecessarily.
5. **Add SSRF validation to `InstanceUpdate` schema (High)** — `InstanceCreate` had URL validation, `InstanceUpdate` did not. An attacker could update an instance URL to `http://169.254.169.254/` to achieve SSRF.
6. **Add bounds to `/api/dashboard/activity` limit parameter (Low)** — Was unbounded, enabling DoS via massive DB scans. Now `Query(10, ge=1, le=100)`.
7. **Constrain `algorithm` config to HS256 only (Medium)** — The field was configurable but silently ignored. Now validates and rejects non-HS256 values.

## Severity: High + Medium + Low

## Test plan

- [ ] Verify CSP header includes `object-src 'none'`
- [ ] Verify `Permissions-Policy` header present in responses
- [ ] Verify `X-XSS-Protection` header is absent
- [ ] Verify CORS `Access-Control-Expose-Headers` is not `*`
- [ ] Verify updating instance URL to a private IP is rejected
- [ ] Verify `/api/dashboard/activity?limit=10000` returns 422
- [ ] Verify `ALGORITHM=RS256` in env causes startup failure

Ref: `docs/security-assessment-2026-02-27.md` findings HIGH-1, MED-1, MED-4, MED-7, LOW-2, LOW-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)