### PR TITLE
security: use client IP for rate limiting behind proxy (fixes #12)

### DIFF
--- a/src/splintarr/api/auth.py
+++ b/src/splintarr/api/auth.py
@@ -17,7 +17,6 @@ from typing import Annotated
 import structlog
 from fastapi import APIRouter, Cookie, Depends, HTTPException, Request, Response, status
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy.orm import Session
 
 from splintarr.config import settings
@@ -39,6 +38,7 @@ from splintarr.core.auth import (
     verify_2fa_pending_token,
     verify_totp_code,
 )
+from splintarr.core.rate_limit import rate_limit_key_func
 from splintarr.core.security import hash_password, verify_password
 from splintarr.database import get_db
 from splintarr.models.user import User
@@ -57,7 +57,7 @@ from splintarr.schemas.user import (
 logger = structlog.get_logger()
 
 # Initialize rate limiter
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=rate_limit_key_func)
 
 # Create router
 router = APIRouter(
@@ -68,10 +68,10 @@ router = APIRouter(
 
 def get_client_ip(request: Request) -> str:
     """
-    Extract client IP address from request.
+    Extract client IP address from request for logging purposes.
 
-    Only trusts X-Forwarded-For in production (where a reverse proxy is expected).
-    In development/test, uses the direct client IP to prevent spoofing.
+    Delegates to the shared rate_limit_key_func to ensure consistent
+    IP extraction logic between rate limiting and audit logging.
 
     Args:
         request: FastAPI request object
@@ -79,14 +79,7 @@ def get_client_ip(request: Request) -> str:
     Returns:
         str: Client IP address
     """
-    # Only trust X-Forwarded-For when behind a reverse proxy (production)
-    # In development, attackers can spoof this header to bypass rate limiting
-    if settings.environment == "production":
-        forwarded = request.headers.get("X-Forwarded-For")
-        if forwarded:
-            # Take the first IP (client IP set by the reverse proxy)
-            return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
+    return rate_limit_key_func(request)
 
 
 def set_auth_cookies(

--- a/src/splintarr/core/rate_limit.py
+++ b/src/splintarr/core/rate_limit.py
@@ -1,0 +1,43 @@
+"""
+Rate limiting utilities for Splintarr.
+
+Provides a proxy-aware key function for slowapi rate limiting that correctly
+extracts client IP addresses when running behind a reverse proxy (production)
+while preventing header spoofing in development/test environments.
+"""
+
+import structlog
+from fastapi import Request
+
+from splintarr.config import settings
+
+logger = structlog.get_logger(__name__)
+
+
+def rate_limit_key_func(request: Request) -> str:
+    """
+    Extract client IP address for rate limiting.
+
+    In production (behind a reverse proxy), trusts the X-Forwarded-For header
+    and returns the first IP (the original client IP set by the proxy).
+
+    In development/test, uses request.client.host directly to prevent
+    attackers from spoofing X-Forwarded-For to bypass rate limits.
+
+    This function is designed to be used as slowapi's key_func parameter.
+
+    Args:
+        request: FastAPI/Starlette request object.
+
+    Returns:
+        Client IP address string, or "unknown" if it cannot be determined.
+    """
+    # Only trust X-Forwarded-For when behind a reverse proxy (production)
+    # In development, attackers can spoof this header to bypass rate limiting
+    if settings.environment == "production":
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            # Take the first IP (client IP set by the reverse proxy)
+            return forwarded.split(",")[0].strip()
+
+    return request.client.host if request.client else "unknown"

--- a/src/splintarr/main.py
+++ b/src/splintarr/main.py
@@ -21,11 +21,11 @@ from fastapi.staticfiles import StaticFiles
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
-from slowapi.util import get_remote_address
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from splintarr.api import auth, dashboard, instances, search_history, search_queue
 from splintarr.config import settings
+from splintarr.core.rate_limit import rate_limit_key_func
 from splintarr.database import (
     close_db,
     database_health_check,
@@ -42,7 +42,7 @@ logger = structlog.get_logger(__name__)
 
 # Initialize rate limiter
 limiter = Limiter(
-    key_func=get_remote_address,
+    key_func=rate_limit_key_func,
     default_limits=[f"{settings.rate_limit_per_minute}/minute"],
     storage_uri="memory://",  # WARNING: In-memory storage does not share state across workers.
     # With workers > 1, each worker has independent rate counters, effectively

--- a/tests/unit/test_rate_limit_key.py
+++ b/tests/unit/test_rate_limit_key.py
@@ -1,0 +1,189 @@
+"""
+Unit tests for rate_limit_key_func.
+
+Verifies that the rate limiting key function correctly extracts client IPs:
+- In production: trusts X-Forwarded-For header (first IP from proxy chain)
+- In dev/test: uses request.client.host directly (ignores X-Forwarded-For)
+- Handles missing request.client gracefully
+"""
+
+from unittest.mock import MagicMock, patch
+
+from splintarr.core.rate_limit import rate_limit_key_func
+
+
+def _make_request(
+    client_host: str | None = "127.0.0.1",
+    forwarded_for: str | None = None,
+) -> MagicMock:
+    """Create a mock Request with optional client and X-Forwarded-For header."""
+    request = MagicMock()
+
+    if client_host is not None:
+        request.client = MagicMock()
+        request.client.host = client_host
+    else:
+        request.client = None
+
+    headers = {}
+    if forwarded_for is not None:
+        headers["X-Forwarded-For"] = forwarded_for
+    request.headers = headers
+
+    return request
+
+
+class TestRateLimitKeyFuncProduction:
+    """Tests for production environment (behind a reverse proxy)."""
+
+    @patch("splintarr.core.rate_limit.settings")
+    def test_uses_x_forwarded_for_in_production(self, mock_settings: MagicMock) -> None:
+        """In production, X-Forwarded-For header should be trusted."""
+        mock_settings.environment = "production"
+        request = _make_request(client_host="10.0.0.1", forwarded_for="203.0.113.50")
+
+        result = rate_limit_key_func(request)
+
+        assert result == "203.0.113.50"
+
+    @patch("splintarr.core.rate_limit.settings")
+    def test_uses_first_ip_from_forwarded_chain(self, mock_settings: MagicMock) -> None:
+        """When multiple IPs in X-Forwarded-For, use the first (client) IP."""
+        mock_settings.environment = "production"
+        request = _make_request(
+            client_host="10.0.0.1",
+            forwarded_for="203.0.113.50, 198.51.100.1, 10.0.0.1",
+        )
+
+        result = rate_limit_key_func(request)
+
+        assert result == "203.0.113.50"
+
+    @patch("splintarr.core.rate_limit.settings")
+    def test_strips_whitespace_from_forwarded_ip(self, mock_settings: MagicMock) -> None:
+        """Whitespace around IPs in X-Forwarded-For should be stripped."""
+        mock_settings.environment = "production"
+        request = _make_request(
+            client_host="10.0.0.1",
+            forwarded_for="  203.0.113.50 , 198.51.100.1",
+        )
+
+        result = rate_limit_key_func(request)
+
+        assert result == "203.0.113.50"
+
+    @patch("splintarr.core.rate_limit.settings")
+    def test_falls_back_to_client_host_when_no_header(
+        self, mock_settings: MagicMock
+    ) -> None:
+        """In production, if X-Forwarded-For is missing, fall back to client.host."""
+        mock_settings.environment = "production"
+        request = _make_request(client_host="10.0.0.1", forwarded_for=None)
+
+        result = rate_limit_key_func(request)
+
+        assert result == "10.0.0.1"
+
+    @patch("splintarr.core.rate_limit.settings")
+    def test_returns_unknown_when_client_is_none_in_production(
+        self, mock_settings: MagicMock
+    ) -> None:
+        """If request.client is None and no X-Forwarded-For, return 'unknown'."""
+        mock_settings.environment = "production"
+        request = _make_request(client_host=None, forwarded_for=None)
+
+        result = rate_limit_key_func(request)
+
+        assert result == "unknown"
+
+
+class TestRateLimitKeyFuncDevelopment:
+    """Tests for development/test environments (no reverse proxy)."""
+
+    @patch("splintarr.core.rate_limit.settings")
+    def test_ignores_x_forwarded_for_in_development(
+        self, mock_settings: MagicMock
+    ) -> None:
+        """In development, X-Forwarded-For must be ignored to prevent spoofing."""
+        mock_settings.environment = "development"
+        request = _make_request(
+            client_host="127.0.0.1",
+            forwarded_for="203.0.113.50",
+        )
+
+        result = rate_limit_key_func(request)
+
+        assert result == "127.0.0.1"
+
+    @patch("splintarr.core.rate_limit.settings")
+    def test_ignores_x_forwarded_for_in_test(self, mock_settings: MagicMock) -> None:
+        """In test, X-Forwarded-For must be ignored to prevent spoofing."""
+        mock_settings.environment = "test"
+        request = _make_request(
+            client_host="127.0.0.1",
+            forwarded_for="203.0.113.50",
+        )
+
+        result = rate_limit_key_func(request)
+
+        assert result == "127.0.0.1"
+
+    @patch("splintarr.core.rate_limit.settings")
+    def test_uses_client_host_in_development(self, mock_settings: MagicMock) -> None:
+        """In development, always use request.client.host."""
+        mock_settings.environment = "development"
+        request = _make_request(client_host="192.168.1.100")
+
+        result = rate_limit_key_func(request)
+
+        assert result == "192.168.1.100"
+
+    @patch("splintarr.core.rate_limit.settings")
+    def test_returns_unknown_when_client_is_none(
+        self, mock_settings: MagicMock
+    ) -> None:
+        """If request.client is None, return 'unknown'."""
+        mock_settings.environment = "development"
+        request = _make_request(client_host=None)
+
+        result = rate_limit_key_func(request)
+
+        assert result == "unknown"
+
+
+class TestGetClientIpConsistency:
+    """Verify that auth.get_client_ip returns the correct IP (consistent with rate limiter)."""
+
+    @patch("splintarr.core.rate_limit.settings")
+    @patch("splintarr.api.auth.settings")
+    def test_get_client_ip_uses_forwarded_for_in_production(
+        self, mock_auth_settings: MagicMock, mock_rl_settings: MagicMock
+    ) -> None:
+        """get_client_ip should return the X-Forwarded-For IP in production."""
+        from splintarr.api.auth import get_client_ip
+
+        mock_auth_settings.environment = "production"
+        mock_rl_settings.environment = "production"
+        request = _make_request(
+            client_host="10.0.0.1",
+            forwarded_for="203.0.113.50",
+        )
+
+        assert get_client_ip(request) == "203.0.113.50"
+
+    @patch("splintarr.core.rate_limit.settings")
+    @patch("splintarr.api.auth.settings")
+    def test_get_client_ip_ignores_forwarded_for_in_dev(
+        self, mock_auth_settings: MagicMock, mock_rl_settings: MagicMock
+    ) -> None:
+        """get_client_ip should ignore X-Forwarded-For in development."""
+        from splintarr.api.auth import get_client_ip
+
+        mock_auth_settings.environment = "development"
+        mock_rl_settings.environment = "development"
+        request = _make_request(
+            client_host="127.0.0.1",
+            forwarded_for="203.0.113.50",
+        )
+
+        assert get_client_ip(request) == "127.0.0.1"


### PR DESCRIPTION
## Summary
- Create shared `rate_limit_key_func()` in new `core/rate_limit.py` module
- Production: trusts `X-Forwarded-For` header (first IP from reverse proxy)
- Development/test: uses `request.client.host` directly (prevents header spoofing)
- Replace `get_remote_address` with `rate_limit_key_func` in both `main.py` and `api/auth.py` Limiters
- Simplify `get_client_ip()` in auth.py to delegate to the shared function

## Test plan
- [ ] Verify production mode uses X-Forwarded-For first IP
- [ ] Verify dev/test mode ignores X-Forwarded-For
- [ ] Verify multi-IP X-Forwarded-For chain extracts first IP
- [ ] Verify None client handling
- [ ] Run `pytest tests/unit/test_rate_limit_key.py` (11 tests)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)