### PR TITLE
security: disable follow_redirects to prevent API key leak (fixes #16)

### DIFF
--- a/src/splintarr/services/radarr.py
+++ b/src/splintarr/services/radarr.py
@@ -144,7 +144,7 @@ class RadarrClient:
             self._client = httpx.AsyncClient(
                 timeout=httpx.Timeout(self.timeout),
                 verify=self.verify_ssl,
-                follow_redirects=True,  # httpx strips sensitive headers on cross-origin redirects
+                follow_redirects=False,  # Disabled: prevents X-Api-Key leaking to redirect targets
                 headers={
                     "X-Api-Key": self.api_key,
                     "User-Agent": f"{settings.app_name}/0.1.0",
@@ -245,6 +245,20 @@ class RadarrClient:
                 logger.warning("radarr_rate_limit_exceeded", url=self.url)
                 raise RadarrRateLimitError("Rate limit exceeded")
 
+            # Handle redirects (don't follow — prevents API key leaking to redirect target)
+            if 300 <= response.status_code < 400:
+                location = response.headers.get("Location", "unknown")
+                logger.warning(
+                    "radarr_redirect_not_followed",
+                    url=self.url,
+                    location=location,
+                    status_code=response.status_code,
+                )
+                raise RadarrConnectionError(
+                    f"Instance returned redirect ({response.status_code}) to {location}. "
+                    "Check the instance URL configuration."
+                )
+
             # Handle client errors (4xx)
             if 400 <= response.status_code < 500:
                 error_detail = response.text
@@ -289,6 +303,9 @@ class RadarrClient:
                 error=str(e),
             )
             raise RadarrAPIError(f"HTTP error: {e}") from e
+
+        except RadarrError:
+            raise
 
         except Exception as e:
             logger.error("radarr_unexpected_error", url=self.url, error=str(e))

--- a/src/splintarr/services/sonarr.py
+++ b/src/splintarr/services/sonarr.py
@@ -144,7 +144,7 @@ class SonarrClient:
             self._client = httpx.AsyncClient(
                 timeout=httpx.Timeout(self.timeout),
                 verify=self.verify_ssl,
-                follow_redirects=True,  # httpx strips sensitive headers on cross-origin redirects
+                follow_redirects=False,  # Disabled: prevents X-Api-Key leaking to redirect targets
                 headers={
                     "X-Api-Key": self.api_key,
                     "User-Agent": f"{settings.app_name}/0.1.0",
@@ -245,6 +245,20 @@ class SonarrClient:
                 logger.warning("sonarr_rate_limit_exceeded", url=self.url)
                 raise SonarrRateLimitError("Rate limit exceeded")
 
+            # Handle redirects (don't follow — prevents API key leaking to redirect target)
+            if 300 <= response.status_code < 400:
+                location = response.headers.get("Location", "unknown")
+                logger.warning(
+                    "sonarr_redirect_not_followed",
+                    url=self.url,
+                    location=location,
+                    status_code=response.status_code,
+                )
+                raise SonarrConnectionError(
+                    f"Instance returned redirect ({response.status_code}) to {location}. "
+                    "Check the instance URL configuration."
+                )
+
             # Handle client errors (4xx)
             if 400 <= response.status_code < 500:
                 error_detail = response.text
@@ -289,6 +303,9 @@ class SonarrClient:
                 error=str(e),
             )
             raise SonarrAPIError(f"HTTP error: {e}") from e
+
+        except SonarrError:
+            raise
 
         except Exception as e:
             logger.error("sonarr_unexpected_error", url=self.url, error=str(e))

--- a/tests/unit/test_api_key_redirect.py
+++ b/tests/unit/test_api_key_redirect.py
@@ -1,0 +1,316 @@
+"""
+Unit tests for API key redirect protection (GitHub issue #16).
+
+Verifies that Sonarr and Radarr clients:
+- Do NOT follow HTTP redirects (prevents X-Api-Key leaking to redirect targets)
+- Raise connection errors with helpful messages when a redirect is received
+- Include the redirect Location header in the error message
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from splintarr.services.radarr import RadarrClient, RadarrConnectionError
+from splintarr.services.sonarr import SonarrClient, SonarrConnectionError
+
+
+class TestSonarrRedirectProtection:
+    """Test that Sonarr client does not follow redirects (API key leak prevention)."""
+
+    @pytest.mark.asyncio
+    async def test_client_created_with_follow_redirects_false(self):
+        """Test that httpx.AsyncClient is created with follow_redirects=False."""
+        client = SonarrClient(
+            url="https://sonarr.example.com",
+            api_key="a" * 32,
+        )
+
+        await client._ensure_client()
+
+        assert client._client is not None
+        assert client._client.follow_redirects is False
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_301_redirect_raises_connection_error(self):
+        """Test that a 301 Moved Permanently raises SonarrConnectionError."""
+        client = SonarrClient(
+            url="https://sonarr.example.com",
+            api_key="a" * 32,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 301
+        mock_response.headers = {"Location": "https://evil.example.com/api/v3/system/status"}
+
+        with patch.object(client, "_ensure_client", new_callable=AsyncMock):
+            with patch.object(client, "_rate_limit", new_callable=AsyncMock):
+                client._client = AsyncMock()
+                client._client.request = AsyncMock(return_value=mock_response)
+
+                with pytest.raises(SonarrConnectionError, match="redirect.*301") as exc_info:
+                    await client._request("GET", "/api/v3/system/status")
+
+                assert "evil.example.com" in str(exc_info.value)
+                assert "Check the instance URL configuration" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_302_redirect_raises_connection_error(self):
+        """Test that a 302 Found raises SonarrConnectionError."""
+        client = SonarrClient(
+            url="http://sonarr.example.com",
+            api_key="a" * 32,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 302
+        mock_response.headers = {"Location": "https://sonarr.example.com/api/v3/system/status"}
+
+        with patch.object(client, "_ensure_client", new_callable=AsyncMock):
+            with patch.object(client, "_rate_limit", new_callable=AsyncMock):
+                client._client = AsyncMock()
+                client._client.request = AsyncMock(return_value=mock_response)
+
+                with pytest.raises(SonarrConnectionError, match="redirect.*302"):
+                    await client._request("GET", "/api/v3/system/status")
+
+    @pytest.mark.asyncio
+    async def test_307_redirect_raises_connection_error(self):
+        """Test that a 307 Temporary Redirect raises SonarrConnectionError."""
+        client = SonarrClient(
+            url="https://sonarr.example.com",
+            api_key="a" * 32,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 307
+        mock_response.headers = {"Location": "https://other.example.com/"}
+
+        with patch.object(client, "_ensure_client", new_callable=AsyncMock):
+            with patch.object(client, "_rate_limit", new_callable=AsyncMock):
+                client._client = AsyncMock()
+                client._client.request = AsyncMock(return_value=mock_response)
+
+                with pytest.raises(SonarrConnectionError, match="redirect.*307"):
+                    await client._request("GET", "/api/v3/system/status")
+
+    @pytest.mark.asyncio
+    async def test_308_redirect_raises_connection_error(self):
+        """Test that a 308 Permanent Redirect raises SonarrConnectionError."""
+        client = SonarrClient(
+            url="https://sonarr.example.com",
+            api_key="a" * 32,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 308
+        mock_response.headers = {"Location": "https://new.example.com/sonarr/"}
+
+        with patch.object(client, "_ensure_client", new_callable=AsyncMock):
+            with patch.object(client, "_rate_limit", new_callable=AsyncMock):
+                client._client = AsyncMock()
+                client._client.request = AsyncMock(return_value=mock_response)
+
+                with pytest.raises(SonarrConnectionError, match="redirect.*308"):
+                    await client._request("GET", "/api/v3/system/status")
+
+    @pytest.mark.asyncio
+    async def test_redirect_missing_location_header(self):
+        """Test redirect handling when Location header is absent."""
+        client = SonarrClient(
+            url="https://sonarr.example.com",
+            api_key="a" * 32,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 301
+        mock_response.headers = {}  # No Location header
+
+        with patch.object(client, "_ensure_client", new_callable=AsyncMock):
+            with patch.object(client, "_rate_limit", new_callable=AsyncMock):
+                client._client = AsyncMock()
+                client._client.request = AsyncMock(return_value=mock_response)
+
+                with pytest.raises(SonarrConnectionError, match="unknown"):
+                    await client._request("GET", "/api/v3/system/status")
+
+    @pytest.mark.asyncio
+    async def test_redirect_does_not_leak_api_key(self):
+        """Test that API key is NOT sent to redirect destination.
+
+        Since follow_redirects=False, the client never makes a second request.
+        We verify only one request was made (the original), and it raised an error.
+        """
+        client = SonarrClient(
+            url="https://sonarr.example.com",
+            api_key="a" * 32,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 302
+        mock_response.headers = {"Location": "https://attacker.example.com/steal-key"}
+
+        with patch.object(client, "_ensure_client", new_callable=AsyncMock):
+            with patch.object(client, "_rate_limit", new_callable=AsyncMock):
+                mock_request = AsyncMock(return_value=mock_response)
+                client._client = AsyncMock()
+                client._client.request = mock_request
+
+                with pytest.raises(SonarrConnectionError):
+                    await client._request("GET", "/api/v3/system/status")
+
+                # Verify only ONE request was made (no follow-up to redirect target)
+                assert mock_request.call_count == 1
+
+
+class TestRadarrRedirectProtection:
+    """Test that Radarr client does not follow redirects (API key leak prevention)."""
+
+    @pytest.mark.asyncio
+    async def test_client_created_with_follow_redirects_false(self):
+        """Test that httpx.AsyncClient is created with follow_redirects=False."""
+        client = RadarrClient(
+            url="https://radarr.example.com",
+            api_key="a" * 32,
+        )
+
+        await client._ensure_client()
+
+        assert client._client is not None
+        assert client._client.follow_redirects is False
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_301_redirect_raises_connection_error(self):
+        """Test that a 301 Moved Permanently raises RadarrConnectionError."""
+        client = RadarrClient(
+            url="https://radarr.example.com",
+            api_key="a" * 32,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 301
+        mock_response.headers = {"Location": "https://evil.example.com/api/v3/system/status"}
+
+        with patch.object(client, "_ensure_client", new_callable=AsyncMock):
+            with patch.object(client, "_rate_limit", new_callable=AsyncMock):
+                client._client = AsyncMock()
+                client._client.request = AsyncMock(return_value=mock_response)
+
+                with pytest.raises(RadarrConnectionError, match="redirect.*301") as exc_info:
+                    await client._request("GET", "/api/v3/system/status")
+
+                assert "evil.example.com" in str(exc_info.value)
+                assert "Check the instance URL configuration" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_302_redirect_raises_connection_error(self):
+        """Test that a 302 Found raises RadarrConnectionError."""
+        client = RadarrClient(
+            url="http://radarr.example.com",
+            api_key="a" * 32,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 302
+        mock_response.headers = {"Location": "https://radarr.example.com/api/v3/system/status"}
+
+        with patch.object(client, "_ensure_client", new_callable=AsyncMock):
+            with patch.object(client, "_rate_limit", new_callable=AsyncMock):
+                client._client = AsyncMock()
+                client._client.request = AsyncMock(return_value=mock_response)
+
+                with pytest.raises(RadarrConnectionError, match="redirect.*302"):
+                    await client._request("GET", "/api/v3/system/status")
+
+    @pytest.mark.asyncio
+    async def test_307_redirect_raises_connection_error(self):
+        """Test that a 307 Temporary Redirect raises RadarrConnectionError."""
+        client = RadarrClient(
+            url="https://radarr.example.com",
+            api_key="a" * 32,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 307
+        mock_response.headers = {"Location": "https://other.example.com/"}
+
+        with patch.object(client, "_ensure_client", new_callable=AsyncMock):
+            with patch.object(client, "_rate_limit", new_callable=AsyncMock):
+                client._client = AsyncMock()
+                client._client.request = AsyncMock(return_value=mock_response)
+
+                with pytest.raises(RadarrConnectionError, match="redirect.*307"):
+                    await client._request("GET", "/api/v3/system/status")
+
+    @pytest.mark.asyncio
+    async def test_308_redirect_raises_connection_error(self):
+        """Test that a 308 Permanent Redirect raises RadarrConnectionError."""
+        client = RadarrClient(
+            url="https://radarr.example.com",
+            api_key="a" * 32,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 308
+        mock_response.headers = {"Location": "https://new.example.com/radarr/"}
+
+        with patch.object(client, "_ensure_client", new_callable=AsyncMock):
+            with patch.object(client, "_rate_limit", new_callable=AsyncMock):
+                client._client = AsyncMock()
+                client._client.request = AsyncMock(return_value=mock_response)
+
+                with pytest.raises(RadarrConnectionError, match="redirect.*308"):
+                    await client._request("GET", "/api/v3/system/status")
+
+    @pytest.mark.asyncio
+    async def test_redirect_missing_location_header(self):
+        """Test redirect handling when Location header is absent."""
+        client = RadarrClient(
+            url="https://radarr.example.com",
+            api_key="a" * 32,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 301
+        mock_response.headers = {}
+
+        with patch.object(client, "_ensure_client", new_callable=AsyncMock):
+            with patch.object(client, "_rate_limit", new_callable=AsyncMock):
+                client._client = AsyncMock()
+                client._client.request = AsyncMock(return_value=mock_response)
+
+                with pytest.raises(RadarrConnectionError, match="unknown"):
+                    await client._request("GET", "/api/v3/system/status")
+
+    @pytest.mark.asyncio
+    async def test_redirect_does_not_leak_api_key(self):
+        """Test that API key is NOT sent to redirect destination.
+
+        Since follow_redirects=False, the client never makes a second request.
+        We verify only one request was made (the original), and it raised an error.
+        """
+        client = RadarrClient(
+            url="https://radarr.example.com",
+            api_key="a" * 32,
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 302
+        mock_response.headers = {"Location": "https://attacker.example.com/steal-key"}
+
+        with patch.object(client, "_ensure_client", new_callable=AsyncMock):
+            with patch.object(client, "_rate_limit", new_callable=AsyncMock):
+                mock_request = AsyncMock(return_value=mock_response)
+                client._client = AsyncMock()
+                client._client.request = mock_request
+
+                with pytest.raises(RadarrConnectionError):
+                    await client._request("GET", "/api/v3/system/status")
+
+                # Verify only ONE request was made (no follow-up to redirect target)
+                assert mock_request.call_count == 1


### PR DESCRIPTION
## Summary
- Set `follow_redirects=False` in both `SonarrClient` and `RadarrClient` httpx clients
- Add 3xx redirect handling in `_request()` — logs warning and raises connection error with redirect location
- Sonarr/Radarr REST APIs don't use redirects for normal operations; a redirect indicates misconfiguration
- Added `except SonarrError/RadarrError: raise` to prevent exception re-wrapping

## Test plan
- [ ] Verify `follow_redirects=False` is set on client
- [ ] Verify 301, 302, 307, 308 responses raise appropriate errors
- [ ] Verify error message includes redirect location
- [ ] Verify only one request is made (no redirect followed)
- [ ] Run `pytest tests/unit/test_api_key_redirect.py` (14 tests)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)