### PR TITLE
security: prevent raw exception text in HTTP error responses

### DIFF
--- a/src/splintarr/api/dashboard.py
+++ b/src/splintarr/api/dashboard.py
@@ -620,9 +620,14 @@ async def dashboard_add_instance(
     try:
         validate_instance_url(url, allow_local=settings.allow_local_instances)
     except (SSRFError, ValueError) as e:
+        logger.warning(
+            "instance_url_validation_failed",
+            user_id=current_user.id,
+            error=str(e),
+        )
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST,
-            content={"detail": str(e)},
+            content={"detail": "Invalid instance URL"},
         )
 
     try:

--- a/src/splintarr/api/instances.py
+++ b/src/splintarr/api/instances.py
@@ -619,7 +619,7 @@ async def test_instance_pre_creation(
             )
             return InstanceTestResult(
                 success=False,
-                message=f"Connection failed: {str(e)}",
+                message="Connection failed: unable to reach instance",
                 version=None,
                 items_count=None,
             )
@@ -632,7 +632,7 @@ async def test_instance_pre_creation(
         )
         return InstanceTestResult(
             success=False,
-            message=f"Failed to test connection: {str(e)}",
+            message="Failed to test connection",
             version=None,
             items_count=None,
         )


### PR DESCRIPTION
## Summary
- Replace str(e) in HTTP error response bodies with generic messages across instances.py, dashboard.py, and main.py
- Raw exceptions continue to be logged server-side via structlog for debugging
- Add recursive _sanitize_for_json() helper in main.py to handle bytes values in nested Pydantic validation error structures

## Changes
| File | Fix |
|------|-----|
| src/splintarr/api/instances.py | Replace f-string with str(e) in InstanceTestResult responses with generic messages |
| src/splintarr/api/dashboard.py | Replace str(e) in SSRF/URL validation error JSON response with generic message; add server-side logging |
| src/splintarr/main.py | Extract _sanitize_for_json() recursive helper to handle bytes in nested dicts/lists within Pydantic validation errors |

## Security context
Finding: CRIT-3 from security assessment 2026-02-27

Raw exception messages can disclose internal implementation details (database schema, file paths, library versions, connection strings) to callers. This is an information disclosure vulnerability (CWE-209).

## Test plan
- [ ] Verify POST /api/instances/test with invalid URL returns generic error message, not raw exception
- [ ] Verify dashboard Add Instance with blocked SSRF URL returns Invalid instance URL, not SSRF error details
- [ ] Send malformed bytes payload to a validated endpoint and confirm 422 response serializes without TypeError
- [ ] Confirm raw exception details still appear in structlog output for server-side debugging

Generated with Claude Code