### PR TITLE
security: use proxy-aware rate limiter key in all API modules

### DIFF
--- a/src/splintarr/api/instances.py
+++ b/src/splintarr/api/instances.py
@@ -18,11 +18,11 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, field_validator
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy.orm import Session
 
 from splintarr.api.auth import get_current_user
 from splintarr.config import settings
+from splintarr.core.rate_limit import rate_limit_key_func
 from splintarr.core.security import decrypt_field, encrypt_field
 from splintarr.core.ssrf_protection import SSRFError, validate_instance_url
 from splintarr.database import get_db
@@ -46,7 +46,7 @@ router = APIRouter(
 )
 
 # Rate limiter
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=rate_limit_key_func)
 
 
 def instance_to_response(instance: Instance) -> InstanceResponse:

--- a/src/splintarr/api/library.py
+++ b/src/splintarr/api/library.py
@@ -28,11 +28,11 @@ from fastapi import (
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.templating import Jinja2Templates
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy import case, func
 from sqlalchemy.orm import Session
 
 from splintarr.core.auth import get_current_user_from_cookie
+from splintarr.core.rate_limit import rate_limit_key_func
 from splintarr.database import get_db
 from splintarr.models.instance import Instance
 from splintarr.models.library import LibraryEpisode, LibraryItem
@@ -43,7 +43,7 @@ logger = structlog.get_logger()
 
 router = APIRouter(tags=["library"])
 templates = Jinja2Templates(directory="src/splintarr/templates")
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=rate_limit_key_func)
 
 
 # ============================================================================

--- a/src/splintarr/api/search_history.py
+++ b/src/splintarr/api/search_history.py
@@ -13,10 +13,10 @@ from typing import Any
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy.orm import Session
 
 from splintarr.api.auth import get_current_user
+from splintarr.core.rate_limit import rate_limit_key_func
 from splintarr.database import get_db, get_session_factory
 from splintarr.models import Instance, SearchQueue, User
 from splintarr.schemas import MessageResponse, SearchHistoryResponse
@@ -24,7 +24,7 @@ from splintarr.services import get_history_service
 
 logger = structlog.get_logger()
 
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=rate_limit_key_func)
 router = APIRouter(prefix="/api/search-history", tags=["search-history"])
 
 

--- a/src/splintarr/api/search_queue.py
+++ b/src/splintarr/api/search_queue.py
@@ -13,10 +13,10 @@ from typing import Any
 import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy.orm import Session
 
 from splintarr.api.auth import get_current_user
+from splintarr.core.rate_limit import rate_limit_key_func
 from splintarr.database import get_db, get_session_factory
 from splintarr.models import Instance, SearchQueue, User
 from splintarr.schemas import (
@@ -29,7 +29,7 @@ from splintarr.services import SearchQueueManager, get_history_service, get_sche
 
 logger = structlog.get_logger()
 
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=rate_limit_key_func)
 router = APIRouter(prefix="/api/search-queues", tags=["search-queues"])
 
 


### PR DESCRIPTION
## Summary
Replace `get_remote_address` (slowapi default) with `rate_limit_key_func` (custom proxy-aware IP extractor) in all 4 non-auth API modules.

## Vulnerability
Behind a reverse proxy, `get_remote_address` returns the proxy's IP, not the client's. All users share one rate limit bucket, enabling both DoS of legitimate users and bypass by distributed attackers.

## Fix
Use `rate_limit_key_func` from `splintarr.core.rate_limit` which correctly trusts `X-Forwarded-For` in production mode. This matches the behavior already used in `api/auth.py`.

## Files changed
- `api/instances.py` — import + limiter initialization
- `api/search_queue.py` — import + limiter initialization
- `api/search_history.py` — import + limiter initialization
- `api/library.py` — import + limiter initialization

## Finding reference
HIGH-2 from security assessment 2026-02-27. Note: HIGH-1 (InstanceUpdate SSRF) was already fixed in a prior commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)