### PR TITLE
docs: link accepted security risks from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Documentation is organized following the [Diataxis](https://diataxis.fr/) framew
 ### Explanation (Understanding-Oriented)
 
 - **[Architecture](docs/explanation/architecture.md)** -- System design and architectural decisions
-- **[Security](docs/explanation/security.md)** -- Security model and implementation details
+- **[Security](docs/explanation/security.md)** -- Security model, implementation details, and [accepted risks](docs/explanation/security.md#known-limitations-and-accepted-risks)
 - **[Search Strategies](docs/explanation/search-strategies.md)** -- How different search strategies work
 
 ### Release Information


### PR DESCRIPTION
## Summary
Update the Security entry in the README Documentation section to include a direct link to the accepted risks section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)