### PR TITLE
fix: UX bugs found during E2E testing

### DIFF
--- a/src/splintarr/templates/dashboard/library_missing.html
+++ b/src/splintarr/templates/dashboard/library_missing.html
@@ -44,7 +44,11 @@
 {% else %}
 <article>
     <p class="empty-state">
+        {% if stats.total_items == 0 %}
+        No library data yet. <a href="/dashboard/library">Sync your library</a> first to see missing content.
+        {% else %}
         No missing content found. Your library is complete!
+        {% endif %}
     </p>
 </article>
 {% endif %}

--- a/src/splintarr/templates/dashboard/search_history.html
+++ b/src/splintarr/templates/dashboard/search_history.html
@@ -113,7 +113,7 @@
             <dd>{{ total_count }}</dd>
 
             <dt>Current Page</dt>
-            <dd>{{ page }} of {{ total_pages }}</dd>
+            <dd>{{ page }} of {{ [total_pages, 1]|max }}</dd>
 
             <dt>Per Page</dt>
             <dd>{{ per_page }}</dd>
@@ -122,7 +122,7 @@
 
     <article>
         <h4>Filters</h4>
-        <p><small style="color: var(--muted-color);">Advanced filtering coming soon</small></p>
+        <p><small style="color: var(--muted-color);">Filter by instance, strategy, or date range from the <a href="/api/search-history">API</a>.</small></p>
     </article>
 </div>
 {% endblock %}

--- a/src/splintarr/templates/setup/complete.html
+++ b/src/splintarr/templates/setup/complete.html
@@ -29,7 +29,7 @@
             <ol>
                 <li>
                     <strong>Create Search Queues</strong><br>
-                    <small style="color: var(--muted-color);">Set up automated searches with different strategies (recent, popular, oldest, random)</small>
+                    <small style="color: var(--muted-color);">Set up automated searches with different strategies (missing, cutoff unmet, recent)</small>
                 </li>
                 <li>
                     <strong>Add More Instances</strong><br>

--- a/src/splintarr/templates/setup/instance.html
+++ b/src/splintarr/templates/setup/instance.html
@@ -87,7 +87,7 @@
                     </div>
                 </div>
                 <p style="margin-top: 1rem; text-align: center;">
-                    <small><a href="https://github.com/mminutillo/splintarr#readme" target="_blank" rel="noopener">Need help?</a></small>
+                    <small><a href="https://github.com/menottim/splintarr#readme" target="_blank" rel="noopener">Need help?</a></small>
                 </p>
             </form>
         </article>

--- a/src/splintarr/templates/setup/welcome.html
+++ b/src/splintarr/templates/setup/welcome.html
@@ -51,9 +51,9 @@
             <a href="/setup/admin" role="button">Get Started →</a>
             <p style="margin-top: 1rem; text-align: center;">
                 <small>
-                    <a href="https://github.com/mminutillo/splintarr" target="_blank" rel="noopener">GitHub</a>
+                    <a href="https://github.com/menottim/splintarr" target="_blank" rel="noopener">GitHub</a>
                     &middot;
-                    <a href="https://github.com/mminutillo/splintarr#readme" target="_blank" rel="noopener">Documentation</a>
+                    <a href="https://github.com/menottim/splintarr#readme" target="_blank" rel="noopener">Documentation</a>
                 </small>
             </p>
         </div>


### PR DESCRIPTION
## Summary
Fixes 5 bugs found during end-to-end UX walkthrough with Playwright.

| Bug | Fix |
|-----|-----|
| Wrong GitHub URLs in setup wizard (`mminutillo` → `menottim`) | Fixed in welcome.html, instance.html |
| Setup complete lists wrong strategies ("popular, oldest, random") | Corrected to "missing, cutoff unmet, recent" |
| Search history shows "Page 1 of 0" when empty | Now shows "Page 1 of 1" |
| "Advanced filtering coming soon" placeholder | Replaced with API link |
| Missing page says "library is complete" with no data | Differentiates empty library from complete library |

## Test plan
- [ ] Setup wizard links go to correct GitHub repo
- [ ] Setup complete page lists correct strategies
- [ ] Search history pagination shows correct values when empty
- [ ] Library missing page shows appropriate message when no data synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)