### PR TITLE
docs: update PRD from feature walkthrough — reorder releases, resolve decisions

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -20,6 +20,7 @@ Solo homelab operator managing 1-5 Sonarr/Radarr instances behind Prowlarr, with
 2. **Indexer respect** — Never overwhelm indexers. Throttle intelligently, adapt to limits, and spend API calls where they're most likely to succeed.
 3. **Transparency** — Every search decision (why an item was searched, skipped, or deprioritized) should be visible in logs and the UI.
 4. **Homelab-first** — Docker-first, single-container, no external dependencies beyond Sonarr/Radarr/Prowlarr. No cloud, no Redis, no complexity.
+5. **Stay focused** — Search automation only. Don't try to replace the *arr apps. The community rejected Huntarr's scope creep and Splintarr should learn from that.
 
 ---
 
@@ -75,18 +76,18 @@ Huntarr was the most popular tool in this space until critical security vulnerab
 
 | # | Feature | Status | Release | Notes |
 |---|---------|--------|---------|-------|
-| 1 | [Library Overview](#1-library-overview) | Done | v0.1.0 | PRs #37-40 |
-| 2 | [Content Exclusion Lists](#2-content-exclusion-lists) | Planned | v0.2.0 | High priority, user-requested |
-| 3 | [Health Monitoring & Auto-Recovery](#3-health-monitoring--auto-recovery) | Planned | v0.2.0 | |
-| 4 | [Search Profiles & Templates](#4-search-profiles--templates) | Planned | v0.2.1 | |
-| 5 | [Real-Time Activity Feed](#5-real-time-activity-feed) | Planned | v0.2.1 | |
-| 6 | [Backup & Restore](#6-backup--restore) | Planned | v0.2.1 | |
-| 7 | [Discord Notifications](#7-discord-notifications) | Planned | v0.2.0 | High priority, user-requested |
-| 8 | [Prowlarr Integration](#8-prowlarr-integration) | Planned | v0.3.0 | Enables indexer-aware rate limiting |
-| 9 | [Season Pack Intelligence](#9-season-pack-intelligence) | Planned | v0.3.0 | Sonarr only |
+| 1 | [Library Overview](#1-library-overview) | **Done** | v0.1.0 | PRs #37-40 |
+| 2 | [Content Exclusion Lists](#2-content-exclusion-lists) | Planned | v0.2.0 | User-requested |
+| 7 | [Discord Notifications](#7-discord-notifications) | Planned | v0.2.0 | User-requested |
+| 3 | [Health Monitoring & Auto-Recovery](#3-health-monitoring--auto-recovery) | Planned | v0.2.1 | |
+| 4 | [Clone Queue & Presets](#4-clone-queue--presets) | Planned | v0.2.1 | Simplified from Search Profiles |
+| 5 | [Real-Time Activity Feed](#5-real-time-activity-feed) | Planned | v0.2.1 | WebSocket, useful for debugging |
+| 6 | [Config Export & Integrity Check](#6-config-export--integrity-check) | Planned | v0.2.1 | Simplified from Backup & Restore |
 | 10 | [Adaptive Search Prioritization](#10-adaptive-search-prioritization) | Planned | v0.3.0 | Core search intelligence |
 | 11 | [Search Cooldown Intelligence](#11-search-cooldown-intelligence) | Planned | v0.3.0 | Builds on #10 |
 | 12 | [Search Result Feedback Loop](#12-search-result-feedback-loop) | Planned | v0.3.0 | Closes the learning loop |
+| 8 | [Prowlarr Integration](#8-prowlarr-integration) | Planned | v0.3.1 | Indexer-aware rate limiting |
+| 9 | [Season Pack Intelligence](#9-season-pack-intelligence) | Planned | v0.3.1 | Sonarr only |
 | 13 | [Search Analytics Dashboard](#13-search-analytics-dashboard) | Deferred | v0.4.0+ | |
 
 ---
@@ -99,11 +100,11 @@ Huntarr was the most popular tool in this space until critical security vulnerab
 
 Pulls and caches series/movie data from connected Sonarr/Radarr instances. Poster grid, missing content view, per-item detail with episode breakdown. Background sync every 6 hours (configurable). Poster images cached locally.
 
-**Resolved decisions:** Local poster cache (not proxy). Per-episode tracking for Sonarr. Quality profile stored as ID.
-
 ---
 
 ## v0.2.0 — Ship First
+
+Two high-value, low-effort features that address the most immediate user needs.
 
 ### 2. Content Exclusion Lists
 
@@ -123,23 +124,9 @@ Pulls and caches series/movie data from connected Sonarr/Radarr instances. Poste
 - Exclusion management page: view all, filter by instance/type, remove
 - Exclusions checked before search execution (skip excluded items, log as "skipped: excluded")
 - Bulk exclude: select multiple items from library grid
+- **Excluded items remain visible in the library** with an "excluded" badge — search-only exclusion, not hidden from view
 
 **Data model:** New `search_exclusions` table (id, instance_id, library_item_id, external_id, content_type, title, reason, expires_at, created_at)
-
-### 3. Health Monitoring & Auto-Recovery
-
-**Priority:** High | **Effort:** Medium | **Status:** Planned
-
-**Problem:** When a Sonarr/Radarr instance goes down, queues fail silently until the user notices. The current 5-failure auto-deactivation burns through the failure budget and doesn't auto-recover.
-
-**Requirements:**
-- Periodic health checks: ping each instance every N minutes (configurable, default 5)
-- Auto-pause queues when instance is unreachable (instead of burning through failure budget)
-- Auto-resume queues when instance recovers, with a backoff period
-- Dashboard health indicator: green/yellow/red per instance
-- Connection quality metrics: response time, timeout rate, error rate over 24h
-
-**Data model:** New `health_checks` table (instance_id, checked_at, success, response_time_ms, error_message). Add `health_check_interval_minutes` to `instances`.
 
 ### 7. Discord Notifications
 
@@ -156,7 +143,8 @@ Pulls and caches series/movie data from connected Sonarr/Radarr instances. Poste
 - Discord webhook URL configuration in Settings
 - Event types (each independently toggleable): content grabbed, queue failed, instance lost/recovered, library sync completed
 - Rich Discord embeds: poster thumbnail, item title, quality, instance name
-- Rate limit: max 1 notification per event type per 5 minutes (prevent spam)
+- **Batched notifications**: one summary embed per search run (not per item) to prevent spam
+- Rate limit: max 1 notification per event type per 5 minutes
 - Test button in settings to verify webhook connectivity
 
 **Data model:** New `notification_config` table (id, webhook_url_encrypted, events_enabled_json, is_active, last_sent_at)
@@ -165,25 +153,42 @@ Pulls and caches series/movie data from connected Sonarr/Radarr instances. Poste
 
 ## v0.2.1 — Ship Next
 
-### 4. Search Profiles & Templates
+Operational improvements and debugging tools.
+
+### 3. Health Monitoring & Auto-Recovery
+
+**Priority:** High | **Effort:** Medium | **Status:** Planned
+
+**Problem:** When a Sonarr/Radarr instance goes down, queues fail silently until the user notices. The current 5-failure auto-deactivation burns through the failure budget and doesn't auto-recover.
+
+**Requirements:**
+- Periodic health checks: ping each instance every N minutes (configurable, default 5)
+- **Connectivity check only** (`/api/v3/system/status`) — fast and low overhead. API key validity tested when searches run.
+- Auto-pause queues when instance is unreachable (instead of burning through failure budget)
+- Auto-resume queues when instance recovers, with a backoff period
+- Dashboard health indicator: green/yellow/red per instance
+
+**Data model:** New `health_checks` table (instance_id, checked_at, success, response_time_ms, error_message). Add `health_check_interval_minutes` to `instances`.
+
+### 4. Clone Queue & Presets
 
 **Priority:** Medium | **Effort:** Low | **Status:** Planned
 
-**Problem:** Creating search queues is repetitive with 3-5 instances. Same strategy, same interval — configured manually each time.
+*Simplified from the original "Search Profiles & Templates" feature. A full profiles system is overengineered for 1-5 instances.*
+
+**Problem:** Creating search queues is repetitive with multiple instances. Same strategy, same interval — configured manually each time.
 
 **Requirements:**
-- Save queue configuration as reusable template
-- Built-in defaults: "Aggressive Missing" (hourly), "Weekly Cutoff Unmet" (weekly), "New Releases" (every 4h)
-- Apply template to multiple instances at once (batch queue creation)
-- Clone existing queue as starting point
-
-**Data model:** New `search_profiles` table (id, user_id, name, strategy, interval_hours, filters, is_builtin, created_at)
+- "Clone" button on existing queues (copies all settings, user changes instance/name)
+- Built-in presets in the Create Queue modal: "Aggressive Missing" (hourly), "Weekly Cutoff Unmet" (weekly), "New Releases" (every 4h)
+- Selecting a preset pre-fills the form fields (user can override before creating)
+- No separate profiles table — presets are hardcoded, cloning uses the existing queue data
 
 ### 5. Real-Time Activity Feed
 
 **Priority:** Medium | **Effort:** Medium | **Status:** Planned
 
-**Problem:** Dashboard uses AJAX polling (30s). Delay between action and result. Live progress would aid debugging.
+**Problem:** Dashboard uses AJAX polling (30s). Delay between action and result. Live progress useful for debugging.
 
 **Requirements:**
 - WebSocket at `/ws/activity` for real-time updates
@@ -192,25 +197,81 @@ Pulls and caches series/movie data from connected Sonarr/Radarr instances. Poste
 - Connection indicator in dashboard header
 - Per-search live progress: items scanned / total
 
-### 6. Backup & Restore
+### 6. Config Export & Integrity Check
 
 **Priority:** Medium | **Effort:** Low | **Status:** Planned
 
-**Problem:** Encrypted database is a single point of failure. No recovery mechanism.
+*Simplified from the original "Backup & Restore" feature. User handles Docker volume backups externally.*
+
+**Problem:** No way to export configuration or verify database integrity.
 
 **Requirements:**
-- Full backup downloadable from settings
-- Scheduled automatic backups: daily, keep last N (default 7)
-- Restore wizard with integrity verification
-- Configuration-only export as JSON (API keys excluded)
-
-**Data model:** New `backups` table (id, backup_type, file_path, file_size, created_at, status)
+- Configuration export as JSON from settings page (instances, queues, settings — API keys excluded)
+- Database integrity check: run `PRAGMA integrity_check` on demand from settings page
+- Display last integrity check result and database file size
+- No scheduled backups, no restore wizard, no backup retention — user's external backup system handles the data volume
 
 ---
 
-## v0.3.0 — Search Intelligence
+## v0.3.0 — Search Intelligence: Core Algorithm
 
 The core differentiator: making searches smarter, not just scheduled.
+
+### 10. Adaptive Search Prioritization
+
+**Priority:** High | **Effort:** Medium | **Status:** Planned
+
+**Problem:** Fixed ordering wastes API calls on unfindable content. Recently aired content waits behind years-old missing episodes. [Known gap](https://github.com/Sonarr/Sonarr/issues/3067).
+
+**User Stories:**
+- *Recently aired content prioritized (most likely available).*
+- *Items searched 20+ times with no results automatically deprioritized.*
+- *I can see why an item was prioritized/deprioritized in the search log.*
+
+**Requirements:**
+- Score each item before searching based on: recency, search history (failed attempts), time since last search
+- Strategy-specific scoring:
+  - Missing: weight recency (air date) and total search attempts
+  - Cutoff Unmet: weight quality gap (how far below cutoff) and time since last upgrade
+- **Scores visible** in search logs and library detail page — full transparency per design principle
+- Sort the search queue by score before executing
+
+**Data model:** Add `search_attempts`, `last_searched_at` to `library_items`
+
+### 11. Search Cooldown Intelligence
+
+**Priority:** Medium | **Effort:** Low | **Status:** Planned | **Depends on:** #10
+
+**Problem:** 24-hour flat cooldown is a blunt instrument. Fresh content needs more frequent searching; old content needs less.
+
+**Requirements:**
+- **Conservative tiered cooldowns** (gentler on indexers than originally proposed):
+  - Aired/added within 24 hours: 6-hour cooldown
+  - Aired/added within 7 days: 12-hour cooldown
+  - Aired/added within 30 days: 24-hour cooldown
+  - Aired/added 30+ days ago: 72-hour cooldown
+  - Aired/added 1+ year ago: 7-day cooldown
+- Exponential backoff for repeated failures: each consecutive search with no result doubles the cooldown (capped at 14 days)
+- Reset cooldown when: content is newly aired, quality profile changes, or user manually triggers search
+- Configurable: allow users to override with a flat cooldown if they prefer simplicity
+
+### 12. Search Result Feedback Loop
+
+**Priority:** Medium | **Effort:** Medium | **Status:** Planned
+
+**Problem:** Splintarr records "search sent" but not whether anything was grabbed. True success rates unknown.
+
+**Requirements:**
+- After triggering a search, poll the item's status after a configurable delay (default: 15 minutes) to detect grabs
+- Track per-item: searches_triggered, grabs_confirmed, last_grab_at
+- Feed grab data into adaptive prioritization (#10) and cooldown intelligence (#11)
+- Dashboard metric: actual grab rate vs search rate
+
+**Data model:** Add `grabs_confirmed`, `last_grab_at` to `library_items`. Add `grab_confirmed` to search_log.
+
+---
+
+## v0.3.1 — Search Intelligence: External Integrations
 
 ### 8. Prowlarr Integration & Indexer-Aware Rate Limiting
 
@@ -220,14 +281,15 @@ The core differentiator: making searches smarter, not just scheduled.
 
 **User Stories:**
 - *As a Prowlarr user, I want Splintarr to read my indexer configurations and respect each indexer's API limits.*
-- *As a user, I want to see indexer health and usage on the dashboard.*
+- *As a user, I want to see indexer health and API usage on the dashboard.*
 
 **Requirements:**
-- Connect to Prowlarr API (URL + API key)
+- Connect to Prowlarr API (URL + API key, same pattern as Sonarr/Radarr instances)
 - Read indexer list with capabilities and API limits
-- Map indexers to Sonarr/Radarr instances
-- Calculate effective rate limit per instance based on most restrictive indexer
-- Track API call count per indexer per time window
+- Map indexers to Sonarr/Radarr instances (Prowlarr knows which indexers sync to which apps)
+- Calculate effective rate limit per instance based on most restrictive connected indexer
+- Track API call count per indexer per time window (hourly/daily)
+- Dashboard widget showing indexer health and usage
 - Fallback: if Prowlarr not configured, use existing per-instance rate limit
 
 **Data model:** New `prowlarr_config`, `indexers`, `indexer_usage` tables
@@ -243,53 +305,11 @@ The core differentiator: making searches smarter, not just scheduled.
 - *Cutoff unmet season packs should only upgrade quality, not re-download deleted episodes.*
 
 **Requirements:**
-- Group missing episodes by series + season before searching
-- If N+ missing (configurable, default 3), issue `SeasonSearch` instead of `EpisodeSearch`
-- Strategy isolation: both strategies use `SeasonSearch` but Sonarr respects monitored status and quality profile
-- Configurable: enable/disable per queue
-
-### 10. Adaptive Search Prioritization
-
-**Priority:** High | **Effort:** Medium | **Status:** Planned
-
-**Problem:** Fixed ordering wastes API calls on unfindable content. Recently aired content waits behind years-old missing episodes. [Known gap](https://github.com/Sonarr/Sonarr/issues/3067).
-
-**User Stories:**
-- *Recently aired content prioritized (most likely available).*
-- *Items searched 20+ times with no results automatically deprioritized.*
-- *I can see why an item was prioritized/deprioritized in the search log.*
-
-**Requirements:**
-- Score items by: recency, search history (failed attempts), time since last search
-- Strategy-specific: Missing weights air date; Cutoff Unmet weights quality gap
-- Log score in search_metadata for transparency
-
-**Data model:** Add `search_attempts`, `last_searched_at` to `library_items`
-
-### 11. Search Cooldown Intelligence
-
-**Priority:** Medium | **Effort:** Low | **Status:** Planned | **Depends on:** #10
-
-**Problem:** 24-hour flat cooldown is a blunt instrument. Fresh content needs aggressive searching; old content needs less.
-
-**Requirements:**
-- Tiered cooldowns: 2h (just aired) → 6h (this week) → 24h (this month) → 72h (older) → 7d (1yr+)
-- Exponential backoff for repeated failures (capped at 14 days)
-- Reset on: new air date, quality profile change, manual trigger
-
-### 12. Search Result Feedback Loop
-
-**Priority:** Medium | **Effort:** Medium | **Status:** Planned
-
-**Problem:** Splintarr records "search sent" but not whether anything was grabbed. True success rates unknown.
-
-**Requirements:**
-- Poll item status after configurable delay (default 15 min) to detect grabs
-- Track per-item: searches_triggered, grabs_confirmed, last_grab_at
-- Feed into adaptive prioritization and cooldown intelligence
-- Dashboard metric: actual grab rate vs search rate
-
-**Data model:** Add `grabs_confirmed`, `last_grab_at` to `library_items`. Add `grab_confirmed` to search_log.
+- Before per-episode searching, group missing episodes by series + season
+- If N+ missing (configurable, default 3), issue `SeasonSearch` command instead of individual `EpisodeSearch`
+- Strategy isolation: both Missing and Cutoff Unmet strategies use `SeasonSearch`, which respects monitored status and quality profile in Sonarr
+- Configurable: enable/disable season pack mode per queue
+- Sonarr-only — Radarr has no equivalent (movies are single items)
 
 ---
 
@@ -299,7 +319,7 @@ The core differentiator: making searches smarter, not just scheduled.
 
 **Priority:** Low | **Effort:** Medium | **Status:** Deferred
 
-Time-series charts, strategy comparison, instance comparison. Lightweight chart library bundled locally (no CDN).
+Time-series charts, strategy comparison, instance comparison. Lightweight chart library bundled locally (no CDN). Useful for occasional glancing but not a daily need.
 
 ---
 
@@ -307,12 +327,9 @@ Time-series charts, strategy comparison, instance comparison. Lightweight chart 
 
 | # | Question | Context |
 |---|----------|---------|
-| 1 | Prowlarr API stability | Less documented than Sonarr/Radarr. Need to verify indexer rate limit fields. |
+| 1 | Prowlarr API stability | Less documented than Sonarr/Radarr. Need to verify indexer rate limit fields are available. |
 | 2 | Season pack threshold | Default 3+ missing. Configurable per queue or global? |
 | 3 | Feedback loop delay | 15 min between search and status check — right balance? |
-| 4 | Notification batching | Batch 20 grabs into 1 Discord message, or send individually? |
-| 5 | Exclusion scope | Exclude from searches only, or also from library sync? |
-| 6 | Health check scope | Test just connectivity, or also API key validity and config drift? |
 
 ---
 
@@ -326,6 +343,16 @@ Time-series charts, strategy comparison, instance comparison. Lightweight chart 
 | Quality profile display | Store ID for now | 2026-02-27 |
 | Notification channel | Discord webhook as primary | 2026-02-28 |
 | Strategy isolation | Missing and Cutoff Unmet never combined | 2026-02-28 |
+| Exclusion scope | Search-only — items stay visible in library with badge | 2026-02-28 |
+| Health check depth | Connectivity only (/system/status) | 2026-02-28 |
+| Notification batching | One summary embed per search run, not per item | 2026-02-28 |
+| Search Profiles | Simplified to Clone Queue + built-in presets in modal | 2026-02-28 |
+| Backup & Restore | Simplified to Config Export + Integrity Check (user handles volumes) | 2026-02-28 |
+| Cooldown defaults | Conservative — gentler on indexers (6h/12h/24h/72h/7d) | 2026-02-28 |
+| Priority transparency | Scores visible in search logs and library detail | 2026-02-28 |
+| v0.2.0 scope | Exclusion Lists + Discord Notifications only | 2026-02-28 |
+| v0.2.1 scope | Health Monitoring moved here from v0.2.0 | 2026-02-28 |
+| v0.3 split | v0.3.0 = core algorithm, v0.3.1 = Prowlarr + Season Packs | 2026-02-28 |
 
 ---
 
@@ -335,5 +362,7 @@ Time-series charts, strategy comparison, instance comparison. Lightweight chart 
 |------|--------|
 | 2026-02-26 | PRD v0.2 created with Features 1-9 |
 | 2026-02-27 | Feature 1 (Library Overview) implemented |
-| 2026-02-28 | Features 10-15 proposed based on community research |
+| 2026-02-28 | Features 10-12 proposed based on community research |
 | 2026-02-28 | Merged into unified ongoing PRD; versioned PRDs archived |
+| 2026-02-28 | Huntarr incident context added (security vulnerabilities, community response) |
+| 2026-02-28 | Feature walkthrough: simplified #4, #6; reordered releases; resolved 11 open questions |


### PR DESCRIPTION
## Summary
Major PRD update from a feature-by-feature walkthrough.

### Key changes
- **v0.2.0 slimmed down**: just Exclusion Lists + Discord Notifications (user priorities)
- **Health Monitoring moved to v0.2.1**
- **Search Profiles simplified** to Clone Queue + Presets (no separate profiles system)
- **Backup simplified** to Config Export + Integrity Check (user has external backups)
- **v0.3 split**: core algorithm (v0.3.0) ships before Prowlarr/Season Packs (v0.3.1)
- **11 open questions resolved** with specific decisions documented
- **New design principle**: Stay focused — don't try to replace the *arr apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)