### PR TITLE
fix: setup wizard 500 error — wrong method name for login recording

### DIFF
--- a/src/splintarr/api/dashboard.py
+++ b/src/splintarr/api/dashboard.py
@@ -357,7 +357,7 @@ async def setup_admin_create(
 
         # Record first login
         client_ip = request.client.host if request.client else "unknown"
-        user.record_login(client_ip)
+        user.record_successful_login(client_ip)
         db.commit()
 
         # Create auth tokens and set cookies


### PR DESCRIPTION
## Summary
PR #70 introduced a call to `user.record_login()` but the actual method is `user.record_successful_login()`. This caused a 500 error when creating the admin account in the setup wizard.

## Fix
`record_login(client_ip)` → `record_successful_login(client_ip)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)