### PR TITLE
fix: setup wizard 500 — record_login → record_successful_login

### DIFF
--- a/src/splintarr/api/dashboard.py
+++ b/src/splintarr/api/dashboard.py
@@ -357,7 +357,7 @@ async def setup_admin_create(
 
         # Record first login
         client_ip = request.client.host if request.client else "unknown"
-        user.record_login(client_ip)
+        user.record_successful_login(client_ip)
         db.commit()
 
         # Create auth tokens and set cookies


### PR DESCRIPTION
Fixes 500 error from PR #70. Wrong method name.