### PR TITLE
refactor: simplify root config files

### DIFF
--- a/src/splintarr/database.py
+++ b/src/splintarr/database.py
@@ -103,7 +103,7 @@ def set_sqlite_pragma(dbapi_conn: Any, connection_record: Any) -> None:
         # Automatically reclaim free space
         # Note: Skip for in-memory databases as auto_vacuum breaks SQLCipher :memory: databases
         result = cursor.execute("PRAGMA database_list").fetchall()
-        is_memory = any(row[2] == ":memory:" or row[2] == "" for row in result)
+        is_memory = any(row[2] in (":memory:", "") for row in result)
 
         if not is_memory:
             cursor.execute("PRAGMA auto_vacuum = FULL")

--- a/src/splintarr/main.py
+++ b/src/splintarr/main.py
@@ -277,9 +277,6 @@ app.include_router(exclusions.router)
 app.include_router(config.router)
 
 
-# Root endpoint removed - handled by dashboard.router
-
-
 @app.get("/health", tags=["health"])
 async def health_check():
     """


### PR DESCRIPTION
## Summary

**config.py (-83 lines):**
- Consolidate 3 identical `get_*` methods into shared `_get_secret` helper
- Consolidate 3 identical field validators into shared `_validate_secret_field` helper
- Remove redundant `validate_database_kdf_iter` validator (duplicates Field ge/le constraints)
- Remove redundant `validate_environment` validator (duplicates Literal type annotation)
- Simplify `_read_secret` to use Path consistently

**logging_config.py (-21 lines):**
- Extract `_create_file_handler` helper (deduplicates 3 identical RotatingFileHandler setups)

**main.py (-3 lines):**
- Remove dead comment

**database.py (1 line):**
- Simplify `is_memory` check to use `in` operator

Net: **-107 lines** across 4 files. All changes are pure refactors preserving existing behavior.

## Test plan
- [x] All unit + security tests pass (80 pre-existing failures, 663 passed, 7 pre-existing errors — identical to main)
- [x] Ruff lint clean
- [x] Ruff format clean

🤖 Generated with [Claude Code](https://claude.ai/code)