### PR TITLE
fix: dynamic footer version + silence settings 404 console errors

### DIFF
--- a/src/splintarr/__init__.py
+++ b/src/splintarr/__init__.py
@@ -1,5 +1,11 @@
 """Splintarr - Intelligent backlog search automation for Sonarr and Radarr."""
 
-__version__ = "0.1.0"
-__author__ = "Your Name"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("splintarr")
+except PackageNotFoundError:
+    __version__ = "dev"
+
+__author__ = "menottim"
 __license__ = "MIT"

--- a/src/splintarr/api/notifications.py
+++ b/src/splintarr/api/notifications.py
@@ -86,17 +86,14 @@ async def get_notification_config(
     Get the current notification config for the authenticated user.
 
     Returns masked webhook URL and event settings.
-    Returns 404 if no config exists yet.
+    Returns 200 with configured=false if no config exists yet.
     """
     config = (
         db.query(NotificationConfig).filter(NotificationConfig.user_id == current_user.id).first()
     )
 
     if not config:
-        return JSONResponse(
-            status_code=status.HTTP_404_NOT_FOUND,
-            content={"detail": "No notification config found"},
-        )
+        return JSONResponse(content={"configured": False})
 
     logger.debug(
         "notification_config_retrieved",

--- a/src/splintarr/api/prowlarr.py
+++ b/src/splintarr/api/prowlarr.py
@@ -122,15 +122,12 @@ async def get_prowlarr_config(
     Get the current Prowlarr config for the authenticated user.
 
     Returns masked API key and connection settings.
-    Returns 404 if no config exists yet.
+    Returns 200 with configured=false if no config exists yet.
     """
     config = db.query(ProwlarrConfig).filter(ProwlarrConfig.user_id == current_user.id).first()
 
     if not config:
-        return JSONResponse(
-            status_code=status.HTTP_404_NOT_FOUND,
-            content={"detail": "No Prowlarr config found"},
-        )
+        return JSONResponse(content={"configured": False})
 
     logger.debug(
         "prowlarr_config_retrieved",

--- a/src/splintarr/main.py
+++ b/src/splintarr/main.py
@@ -38,6 +38,7 @@ from splintarr.api import (
     search_history,
     search_queue,
 )
+from splintarr import __version__
 from splintarr.config import settings
 from splintarr.core.rate_limit import rate_limit_key_func
 from splintarr.database import (
@@ -208,6 +209,7 @@ async def add_security_headers(request: Request, call_next):
     # Templates access this via {{ request.state.csp_nonce }}
     nonce = secrets.token_urlsafe(16)
     request.state.csp_nonce = nonce
+    request.state.app_version = __version__
 
     try:
         response = await call_next(request)

--- a/src/splintarr/templates/base.html
+++ b/src/splintarr/templates/base.html
@@ -92,7 +92,7 @@
             <!-- Footer -->
             <footer>
                 <small>
-                    Splintarr v0.2.0 &middot;
+                    Splintarr v{{ request.state.app_version }} &middot;
                     <a href="https://github.com/menottim/splintarr" target="_blank">GitHub</a>
                 </small>
             </footer>

--- a/src/splintarr/templates/dashboard/settings.html
+++ b/src/splintarr/templates/dashboard/settings.html
@@ -456,8 +456,8 @@ function showNotificationStatus(message, isError) {
 (async function loadNotificationConfig() {
     try {
         var response = await fetch('/api/notifications/config');
-        if (response.ok) {
-            var data = await response.json();
+        var data = await response.json();
+        if (response.ok && data.configured !== false) {
             document.getElementById('webhook_url').placeholder = data.webhook_url_masked;
             document.getElementById('evt_search_triggered').checked = data.events_enabled.search_triggered || false;
             document.getElementById('evt_queue_failed').checked = data.events_enabled.queue_failed || false;
@@ -609,8 +609,8 @@ function showProwlarrStatus(message, isError) {
 (async function loadProwlarrConfig() {
     try {
         var response = await fetch('/api/prowlarr/config');
-        if (response.ok) {
-            var data = await response.json();
+        var data = await response.json();
+        if (response.ok && data.configured !== false) {
             document.getElementById('prowlarr_url').value = data.url;
             document.getElementById('prowlarr_api_key').placeholder = data.api_key_masked;
             document.getElementById('prowlarr_api_key').required = false;


### PR DESCRIPTION
## Summary

Fixes two bugs found during E2E UI testing with Playwright.

**Fixes #91 — Footer version hardcoded to v0.2.0:**
- `__init__.py` now reads version from `importlib.metadata.version("splintarr")` (falls back to "dev")
- `main.py` injects `request.state.app_version` via the security headers middleware
- `base.html` footer reads `{{ request.state.app_version }}` instead of hardcoded string
- Also fixed `__author__` from "Your Name" to "menottim"

**Fixes #92 — Settings page 404 console errors:**
- Notification and Prowlarr GET config endpoints now return `200 {"configured": false}` instead of 404 when no config exists
- Settings JS checks `data.configured !== false` before populating form fields
- Browser no longer logs network-level errors for a normal "not configured" state

## Test plan
- [x] E2E tested: footer shows dynamic version
- [x] E2E tested: Settings page loads without console errors
- [x] Login, dashboard, all pages render correctly

🤖 Generated with [Claude Code](https://claude.ai/code)