### PR TITLE
fix: setup wizard 6-step progress bars + Docker version display

### DIFF
--- a/src/splintarr/__init__.py
+++ b/src/splintarr/__init__.py
@@ -1,11 +1,29 @@
 """Splintarr - Intelligent backlog search automation for Sonarr and Radarr."""
 
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
-try:
-    __version__ = version("splintarr")
-except PackageNotFoundError:
-    __version__ = "dev"
 
+def _get_version() -> str:
+    """Get version from package metadata, falling back to pyproject.toml."""
+    try:
+        return version("splintarr")
+    except PackageNotFoundError:
+        pass
+
+    # Fallback: read from pyproject.toml (for Docker/source installs)
+    for candidate in [
+        Path(__file__).parent.parent.parent / "pyproject.toml",  # src/splintarr/../../
+        Path("/app/pyproject.toml"),  # Docker container path
+    ]:
+        if candidate.exists():
+            for line in candidate.read_text().splitlines():
+                if line.strip().startswith("version"):
+                    return line.split("=")[1].strip().strip('"').strip("'")
+
+    return "dev"
+
+
+__version__ = _get_version()
 __author__ = "menottim"
 __license__ = "MIT"

--- a/src/splintarr/templates/setup/admin.html
+++ b/src/splintarr/templates/setup/admin.html
@@ -9,7 +9,9 @@
         <span class="step completed" data-step="✓">Welcome</span>
         <span class="step active" data-step="2">Admin Account</span>
         <span class="step" data-step="3">Instance</span>
-        <span class="step" data-step="4">Complete</span>
+        <span class="step" data-step="4">Notifications</span>
+        <span class="step" data-step="5">Prowlarr</span>
+        <span class="step" data-step="6">Complete</span>
     </div>
 
     <hgroup>

--- a/src/splintarr/templates/setup/instance.html
+++ b/src/splintarr/templates/setup/instance.html
@@ -9,7 +9,9 @@
         <span class="step completed" data-step="✓">Welcome</span>
         <span class="step completed" data-step="✓">Admin Account</span>
         <span class="step active" data-step="3">Instance</span>
-        <span class="step" data-step="4">Complete</span>
+        <span class="step" data-step="4">Notifications</span>
+        <span class="step" data-step="5">Prowlarr</span>
+        <span class="step" data-step="6">Complete</span>
     </div>
 
     <hgroup>

--- a/src/splintarr/templates/setup/welcome.html
+++ b/src/splintarr/templates/setup/welcome.html
@@ -9,7 +9,9 @@
         <span class="step active" data-step="1">Welcome</span>
         <span class="step" data-step="2">Admin Account</span>
         <span class="step" data-step="3">Instance</span>
-        <span class="step" data-step="4">Complete</span>
+        <span class="step" data-step="4">Notifications</span>
+        <span class="step" data-step="5">Prowlarr</span>
+        <span class="step" data-step="6">Complete</span>
     </div>
 
     <hgroup>


### PR DESCRIPTION
## Summary

Fixes two bugs found during v0.5.0 E2E testing.

**Fixes #95** — Welcome, Admin, and Instance setup templates still showed the old 4-step progress bar. Updated all 3 to show the new 6-step bar (Welcome, Admin, Instance, Notifications, Prowlarr, Complete).

**Fixes #96** — Footer showed "vdev" in Docker because importlib.metadata can't find the package when running from source. Added fallback that reads version from pyproject.toml (tries both relative path and /app/pyproject.toml Docker path).

🤖 Generated with [Claude Code](https://claude.ai/code)