### PR TITLE
fix(library): sync progress stuck on Preparing sync

### DIFF
--- a/src/splintarr/api/library.py
+++ b/src/splintarr/api/library.py
@@ -489,7 +489,8 @@ async def api_library_sync_status(
     try:
         db = next(get_db())
         try:
-            user = get_current_user_from_cookie(request=request, db=db)
+            access_token = request.cookies.get("access_token")
+            user = await get_current_user_from_cookie(access_token=access_token, db=db)
             authenticated = True
             logger.debug("library_sync_status_checked", user_id=user.id, syncing=_sync_in_progress)
         except Exception:


### PR DESCRIPTION
## Summary

- Fixed sync-status endpoint calling `get_current_user_from_cookie` with wrong arguments (`request=request` instead of `access_token`) and missing `await`
- This caused a silent `TypeError` on every poll during sync, falling through to the unauthenticated fallback returning only `{"syncing": true}` with no progress details
- The UI requires `current_instance` and `stage` fields to display real progress — without them it showed "Preparing sync..." indefinitely even though the sync was working

## Root Cause

The `sync-status` endpoint manually calls `get_current_user_from_cookie` outside of FastAPI's dependency injection. The call passed `request=request` but the function signature expects `access_token: str`. Additionally, the `async` function was not `await`ed. Both issues were masked by the broad `try/except Exception` block designed to handle DB lock contention during sync.

## Test plan

- [x] All 30 library-related unit tests pass
- [x] No new test failures introduced (69 fail / 7 error matches pre-existing baseline)
- [x] Ruff lint passes
- [ ] Manual test: trigger library sync and verify progress overlay shows instance name, stage, and item counts instead of "Preparing sync..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)