### PR TITLE
feat(ui): add hover tooltips to non-obvious table headers

### DIFF
--- a/docs/plans/2026-03-02-table-tooltips-design.md
+++ b/docs/plans/2026-03-02-table-tooltips-design.md
@@ -1,0 +1,68 @@
+# Table Header Tooltips Design
+
+**Date:** 2026-03-02
+**Status:** Approved
+
+## Overview
+
+Add hover tooltips to non-obvious table headers across the app using Pico CSS's built-in `data-tooltip` attribute. Migrate existing `title` attributes to `data-tooltip` for consistency.
+
+## Approach
+
+- Use `data-tooltip="..."` on `<th>` elements (Pico CSS native, zero JS)
+- Only on headers where meaning isn't immediately clear
+- Migrate 3 existing `title` attributes to `data-tooltip`
+
+## Tooltip Inventory
+
+### Dashboard - Recent Search Activity (`dashboard/index.html`)
+
+| Header | Tooltip |
+|--------|---------|
+| Strategy | Search strategy used (missing, cutoff, recent, etc.) |
+| Status | Whether the search completed, failed, or was skipped |
+| Items | Searched: sent to indexer. Eligible: matched queue filters. |
+
+### Dashboard - Indexer Health (`dashboard/index.html`)
+
+| Header | Tooltip |
+|--------|---------|
+| Query Limit | Maximum queries allowed per day by the indexer |
+| Queries Used | Number of queries consumed today |
+
+### Search History (`dashboard/search_history.html`)
+
+| Header | Tooltip |
+|--------|---------|
+| Strategy | Search strategy used (missing, cutoff, recent, etc.) |
+| Status | Whether the search completed, failed, or was skipped |
+| Items | Searched: sent to indexer. Eligible: matched queue filters. |
+| Duration | How long the search execution took |
+
+### Search Queue Detail - Execution History (`dashboard/search_queue_detail.html`)
+
+| Header | Tooltip | Notes |
+|--------|---------|-------|
+| Searched | Items sent to Sonarr/Radarr for search | Migrate from `title` |
+| Eligible | Items matching queue filters that were candidates for searching | Migrate from `title` |
+
+### Search Queue Detail - API Details nested table (`dashboard/search_queue_detail.html`)
+
+| Header | Tooltip |
+|--------|---------|
+| Score | Search priority score based on intelligence settings |
+| Command | API command sent to Sonarr/Radarr |
+
+### Exclusions (`dashboard/exclusions.html`)
+
+| Header | Tooltip |
+|--------|---------|
+| Expires | When this exclusion will automatically be removed |
+
+## Headers Excluded (self-explanatory)
+
+Instance, Queue, Title, Type, Reason, Started, Time, Item, Result, Indexer, empty action column.
+
+## Also Migrate
+
+The `Items` column tooltip text in `dashboard/index.html` uses a `title` attribute on a `<span>` inside the `<td>` (not the `<th>`). This inline tooltip should also be migrated to `data-tooltip` for consistency.

--- a/src/splintarr/templates/dashboard/exclusions.html
+++ b/src/splintarr/templates/dashboard/exclusions.html
@@ -31,7 +31,7 @@
                 <th>Instance</th>
                 <th>Type</th>
                 <th>Reason</th>
-                <th>Expires</th>
+                <th data-tooltip="When this exclusion will automatically be removed">Expires</th>
                 <th style="width: 5rem;"></th>
             </tr>
         </thead>

--- a/src/splintarr/templates/dashboard/index.html
+++ b/src/splintarr/templates/dashboard/index.html
@@ -64,9 +64,9 @@
             <thead>
                 <tr>
                     <th>Instance</th>
-                    <th>Strategy</th>
-                    <th>Status</th>
-                    <th>Items</th>
+                    <th data-tooltip="Search strategy used (missing, cutoff, recent, etc.)">Strategy</th>
+                    <th data-tooltip="Whether the search completed, failed, or was skipped">Status</th>
+                    <th data-tooltip="Searched: sent to indexer. Eligible: matched queue filters.">Items</th>
                     <th>Time</th>
                 </tr>
             </thead>
@@ -96,9 +96,9 @@
                     </td>
                     <td>
                         {% if search.searches_triggered %}
-                        <span title="Searched: items sent to Sonarr/Radarr for search. Eligible: items matching queue filters that were candidates for searching.">{{ search.searches_triggered }} searched{% if search.items_found %} of {{ search.items_found }} eligible{% endif %}</span>
+                        <span data-tooltip="Searched: items sent to indexer. Eligible: matched queue filters.">{{ search.searches_triggered }} searched{% if search.items_found %} of {{ search.items_found }} eligible{% endif %}</span>
                         {% else %}
-                        <span title="Eligible: items matching queue filters that were candidates for searching.">{{ search.items_found or 0 }} eligible</span>
+                        <span data-tooltip="Eligible: items matching queue filters that were candidates for searching.">{{ search.items_found or 0 }} eligible</span>
                         {% endif %}
                     </td>
                     <td>
@@ -133,8 +133,8 @@
                 <thead>
                     <tr>
                         <th>Indexer</th>
-                        <th>Query Limit</th>
-                        <th>Queries Used</th>
+                        <th data-tooltip="Maximum queries allowed per day by the indexer">Query Limit</th>
+                        <th data-tooltip="Number of queries consumed today">Queries Used</th>
                         <th>Status</th>
                     </tr>
                 </thead>
@@ -426,10 +426,10 @@ function updateActivityTable(activities) {
             if (item.items_found) {
                 text += ' of ' + item.items_found + ' eligible';
             }
-            itemsSpan.title = 'Searched: items sent to Sonarr/Radarr for search. Eligible: items matching queue filters that were candidates for searching.';
+            itemsSpan.setAttribute('data-tooltip', 'Searched: sent to indexer. Eligible: matched queue filters.');
         } else {
             text = (item.items_found || 0) + ' eligible';
-            itemsSpan.title = 'Eligible: items matching queue filters that were candidates for searching.';
+            itemsSpan.setAttribute('data-tooltip', 'Eligible: items matching queue filters that were candidates for searching.');
         }
         itemsSpan.textContent = text;
         itemsCell.appendChild(itemsSpan);

--- a/src/splintarr/templates/dashboard/search_history.html
+++ b/src/splintarr/templates/dashboard/search_history.html
@@ -49,11 +49,11 @@
                 <tr>
                     <th>Instance</th>
                     <th>Queue</th>
-                    <th>Strategy</th>
-                    <th>Status</th>
-                    <th>Items</th>
+                    <th data-tooltip="Search strategy used (missing, cutoff, recent, etc.)">Strategy</th>
+                    <th data-tooltip="Whether the search completed, failed, or was skipped">Status</th>
+                    <th data-tooltip="Searched: sent to indexer. Eligible: matched queue filters.">Items</th>
                     <th>Started</th>
-                    <th>Duration</th>
+                    <th data-tooltip="How long the search execution took">Duration</th>
                 </tr>
             </thead>
             <tbody>
@@ -79,9 +79,9 @@
                     </td>
                     <td>
                         {% if item.searches_triggered %}
-                        <span title="Searched: items sent to Sonarr/Radarr for search. Eligible: items matching queue filters that were candidates for searching.">{{ item.searches_triggered }} searched{% if item.items_found %}<br><small>of {{ item.items_found }} eligible</small>{% endif %}</span>
+                        <span data-tooltip="Searched: sent to indexer. Eligible: matched queue filters.">{{ item.searches_triggered }} searched{% if item.items_found %}<br><small>of {{ item.items_found }} eligible</small>{% endif %}</span>
                         {% else %}
-                        <span title="Eligible: items matching queue filters that were candidates for searching.">{{ item.items_found or 0 }} eligible</span>
+                        <span data-tooltip="Eligible: items matching queue filters that were candidates for searching.">{{ item.items_found or 0 }} eligible</span>
                         {% endif %}
                     </td>
                     <td>

--- a/src/splintarr/templates/dashboard/search_queue_detail.html
+++ b/src/splintarr/templates/dashboard/search_queue_detail.html
@@ -111,8 +111,8 @@
                 <tr>
                     <th>Started</th>
                     <th>Status</th>
-                    <th title="Items sent to Sonarr/Radarr for search">Searched</th>
-                    <th title="Items matching queue filters that were candidates for searching">Eligible</th>
+                    <th data-tooltip="Items sent to Sonarr/Radarr for search">Searched</th>
+                    <th data-tooltip="Items matching queue filters that were candidates for searching">Eligible</th>
                     <th>Duration</th>
                 </tr>
             </thead>
@@ -155,8 +155,8 @@
                                     <thead>
                                         <tr>
                                             <th>Item</th>
-                                            <th>Score</th>
-                                            <th>Command</th>
+                                            <th data-tooltip="Search priority score based on intelligence settings">Score</th>
+                                            <th data-tooltip="API command sent to Sonarr/Radarr">Command</th>
                                             <th>Result</th>
                                         </tr>
                                     </thead>


### PR DESCRIPTION
## Summary

- Added `data-tooltip` attributes to 14 non-obvious table headers across 4 pages using Pico CSS native tooltip support
- Migrated 3 existing `title` attributes to `data-tooltip` for consistent styled tooltips
- Also migrated JS-rendered tooltip attributes in the dashboard activity polling code
- Zero JS overhead — Pico CSS renders tooltips via CSS pseudo-elements on hover/focus

## Pages affected

| Page | Headers with tooltips |
|------|----------------------|
| Dashboard - Recent Activity | Strategy, Status, Items |
| Dashboard - Indexer Health | Query Limit, Queries Used |
| Search History | Strategy, Status, Items, Duration |
| Queue Detail - Execution History | Searched, Eligible |
| Queue Detail - API Details | Score, Command |
| Exclusions | Expires |

## Test plan

- [ ] Hover over each tooltip header in all 4 pages, verify styled Pico tooltip appears
- [ ] Verify JS-rendered dashboard activity rows also show data-tooltip on Items column
- [ ] Verify no visual regression on tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)