### PR TITLE
fix(docker): footer shows vdev instead of actual version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,6 +69,7 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --chown=appuser:appuser src/ ./src/
 COPY --chown=appuser:appuser alembic/ ./alembic/
 COPY --chown=appuser:appuser alembic.ini ./
+COPY --chown=appuser:appuser pyproject.toml ./
 
 # Create data directory
 RUN mkdir -p /data && chown appuser:appuser /data

--- a/src/splintarr/templates/base.html
+++ b/src/splintarr/templates/base.html
@@ -92,7 +92,13 @@
             <!-- Footer -->
             <footer>
                 <small>
-                    Splintarr v{{ request.state.app_version }} &middot;
+                    Splintarr
+                    {% if request.state.app_version != 'dev' %}
+                    <a href="https://github.com/menottim/splintarr/releases/tag/v{{ request.state.app_version }}" target="_blank">v{{ request.state.app_version }}</a>
+                    {% else %}
+                    v{{ request.state.app_version }}
+                    {% endif %}
+                    &middot;
                     <a href="https://github.com/menottim/splintarr" target="_blank">GitHub</a>
                 </small>
             </footer>


### PR DESCRIPTION
## Summary

- Copy `pyproject.toml` to Docker runtime stage so version fallback in `__init__.py` can read it
- Updated footer to link version number to the corresponding GitHub release page
- When version is "dev" (local dev without `poetry install`), shows unlinked "vdev" as before

## Root Cause

The `_get_version()` fallback chain tries: (1) installed package metadata, (2) `pyproject.toml` at known paths. In Docker, `poetry install --no-root` doesn't install package metadata, and `pyproject.toml` was only in the builder stage, not copied to the runtime stage.

## Test plan

- [ ] `docker-compose build && docker-compose up -d` → footer shows "v1.0.0-alpha" linked to release
- [ ] Clicking the version link goes to `github.com/menottim/splintarr/releases/tag/v1.0.0-alpha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)