### PR TITLE
fix(ui): soften tooltip styling

### DIFF
--- a/src/splintarr/static/css/custom.css
+++ b/src/splintarr/static/css/custom.css
@@ -58,6 +58,15 @@ table th {
 }
 
 table td { color: var(--color); }
+
+/* Softer tooltips — override uppercase/spacing inherited from th */
+[data-tooltip]::after {
+    text-transform: none;
+    letter-spacing: normal;
+    font-weight: 400;
+    font-size: 0.75rem;
+    opacity: 0.9;
+}
 table code { font-size: 0.75em; }
 
 /* Modal dialogs */


### PR DESCRIPTION
## Summary

- Tooltips were rendering in ALL CAPS with wide letter-spacing because they inherited `text-transform: uppercase` and `letter-spacing: 0.5px` from the `table th` CSS rules
- Added CSS override on `[data-tooltip]::after` to reset to normal case, regular weight, and slightly reduced opacity

## Test plan

- [ ] Hover over any table header tooltip — verify lowercase, softer appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)