### PR TITLE
fix(ui): target correct pseudo-element for tooltip text

### DIFF
--- a/src/splintarr/static/css/custom.css
+++ b/src/splintarr/static/css/custom.css
@@ -59,13 +59,13 @@ table th {
 
 table td { color: var(--color); }
 
-/* Softer tooltips — override uppercase/spacing inherited from th */
-[data-tooltip]::after {
+/* Softer tooltips — override uppercase/spacing inherited from th.
+   Pico CSS: ::before = tooltip text, ::after = arrow */
+[data-tooltip]::before {
     text-transform: none;
     letter-spacing: normal;
     font-weight: 400;
     font-size: 0.75rem;
-    opacity: 0.9;
 }
 table code { font-size: 0.75em; }
 


### PR DESCRIPTION
## Summary

Pico CSS tooltip anatomy: `::before` = text content, `::after` = arrow. Previous fix (#103) targeted `::after`, so `<th>` tooltips remained uppercase. Now correctly targets `::before`.

## Test plan

- [ ] Hover over table header tooltips — verify ALL show lowercase, soft styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)