### PR TITLE
fix(ui): force tooltip text styling override

### DIFF
--- a/src/splintarr/static/css/custom.css
+++ b/src/splintarr/static/css/custom.css
@@ -60,12 +60,14 @@ table th {
 table td { color: var(--color); }
 
 /* Softer tooltips — override uppercase/spacing inherited from th.
-   Pico CSS: ::before = tooltip text, ::after = arrow */
-[data-tooltip]::before {
-    text-transform: none;
-    letter-spacing: normal;
-    font-weight: 400;
-    font-size: 0.75rem;
+   Pico CSS: ::before = tooltip text, ::after = arrow.
+   !important needed to beat Pico's cascade + inherited text-transform. */
+[data-tooltip]::before,
+[data-tooltip]::after {
+    text-transform: none !important;
+    letter-spacing: normal !important;
+    font-weight: 400 !important;
+    font-size: 0.75rem !important;
 }
 table code { font-size: 0.75em; }
 


### PR DESCRIPTION
## Summary

Previous tooltip fixes (#103, #104) didn't fully resolve uppercase rendering. Applied `!important` to both `::before` and `::after` pseudo-elements to guarantee the override beats Pico CSS cascade and inherited `text-transform`.

## Test plan

- [ ] Hard refresh (Cmd+Shift+R) and hover over ALL tooltip headers and inline spans — verify lowercase

🤖 Generated with [Claude Code](https://claude.com/claude-code)