### PR TITLE
fix(ui): indexer health tooltips clipped by overflow wrapper

### DIFF
--- a/src/splintarr/templates/dashboard/index.html
+++ b/src/splintarr/templates/dashboard/index.html
@@ -128,23 +128,21 @@
         <header>
             <h3>Indexer Health</h3>
         </header>
-        <div class="overflow-auto">
-            <table id="indexer-health-table" role="grid">
-                <thead>
-                    <tr>
-                        <th>Indexer</th>
-                        <th data-tooltip="Maximum queries allowed per day by the indexer">Query Limit</th>
-                        <th data-tooltip="Number of queries consumed today">Queries Used</th>
-                        <th>Status</th>
-                    </tr>
-                </thead>
-                <tbody id="indexer-health-body">
-                    <tr>
-                        <td colspan="4" style="text-align: center; color: var(--muted-color);">Loading...</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
+        <table id="indexer-health-table" role="grid">
+            <thead>
+                <tr>
+                    <th>Indexer</th>
+                    <th data-tooltip="Maximum queries allowed per day by the indexer">Query Limit</th>
+                    <th data-tooltip="Number of queries consumed today">Queries Used</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+            <tbody id="indexer-health-body">
+                <tr>
+                    <td colspan="4" style="text-align: center; color: var(--muted-color);">Loading...</td>
+                </tr>
+            </tbody>
+        </table>
     </article>
 </div>
 


### PR DESCRIPTION
## Summary

- Removed `overflow-auto` div wrapper around indexer health table
- The wrapper created a CSS clipping boundary that hid Pico tooltips (positioned absolutely above the `<th>`)
- Table only has 4 columns and doesn't need horizontal scroll

## Test plan

- [ ] Hover over "Query Limit" and "Queries Used" headers on dashboard — verify tooltips appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)