### PR TITLE
refactor: simplify dashboard queries and template duplication

### DIFF
--- a/src/splintarr/api/dashboard.py
+++ b/src/splintarr/api/dashboard.py
@@ -74,15 +74,9 @@ def _get_integration_status(
 ) -> dict[str, Any]:
     """Get Discord and Prowlarr integration status for the system status panel."""
     discord_config = (
-        db.query(NotificationConfig)
-        .filter(NotificationConfig.user_id == user_id)
-        .first()
+        db.query(NotificationConfig).filter(NotificationConfig.user_id == user_id).first()
     )
-    prowlarr_config = (
-        db.query(ProwlarrConfig)
-        .filter(ProwlarrConfig.user_id == user_id)
-        .first()
-    )
+    prowlarr_config = db.query(ProwlarrConfig).filter(ProwlarrConfig.user_id == user_id).first()
 
     discord: dict[str, Any] = {
         "configured": discord_config is not None,
@@ -1152,20 +1146,18 @@ async def get_dashboard_stats(db: Session, user: User) -> dict[str, Any]:
 
     success_rate = (successful_searches / searches_this_week * 100) if searches_this_week > 0 else 0
 
-    # Grab rate from library search intelligence
+    # Grab rate from library search intelligence: 1 query with two aggregates
     user_instance_ids = db.query(Instance.id).filter(Instance.user_id == user.id)
-    total_search_attempts = (
-        db.query(func.sum(LibraryItem.search_attempts))
+    grab_stats = (
+        db.query(
+            func.coalesce(func.sum(LibraryItem.search_attempts), 0).label("attempts"),
+            func.coalesce(func.sum(LibraryItem.grabs_confirmed), 0).label("grabs"),
+        )
         .filter(LibraryItem.instance_id.in_(user_instance_ids))
-        .scalar()
-        or 0
+        .one()
     )
-    total_grabs = (
-        db.query(func.sum(LibraryItem.grabs_confirmed))
-        .filter(LibraryItem.instance_id.in_(user_instance_ids))
-        .scalar()
-        or 0
-    )
+    total_search_attempts = int(grab_stats.attempts)
+    total_grabs = int(grab_stats.grabs)
     grab_rate = (
         round(total_grabs / total_search_attempts * 100, 1) if total_search_attempts > 0 else 0.0
     )

--- a/src/splintarr/services/scheduler.py
+++ b/src/splintarr/services/scheduler.py
@@ -548,15 +548,18 @@ def get_scheduler_status() -> dict[str, Any]:
         dict: Scheduler status with 'status' ('running'|'paused'|'stopped')
               and 'jobs_count' (int).
     """
-    result: dict[str, Any] = {"status": "stopped", "jobs_count": 0}
-    if _scheduler_instance:
-        info = _scheduler_instance.get_status()
-        if info["running"] and info["paused"]:
-            result["status"] = "paused"
-        elif info["running"]:
-            result["status"] = "running"
-        result["jobs_count"] = info["jobs_count"]
-    return result
+    if not _scheduler_instance:
+        return {"status": "stopped", "jobs_count": 0}
+
+    info = _scheduler_instance.get_status()
+    if info["paused"]:
+        status = "paused"
+    elif info["running"]:
+        status = "running"
+    else:
+        status = "stopped"
+
+    return {"status": status, "jobs_count": info["jobs_count"]}
 
 
 def get_scheduler(db_session_factory: Callable[[], Session]) -> SearchScheduler:

--- a/src/splintarr/templates/dashboard/index.html
+++ b/src/splintarr/templates/dashboard/index.html
@@ -204,40 +204,24 @@
             <!-- Integrations -->
             <div id="system-status-integrations" style="margin-top: 0.75rem;">
                 <small style="color: var(--muted-color); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.05em;">Integrations</small>
+                {% for name, href, info in [
+                    ('Discord', '/dashboard/settings#notifications', integrations.discord),
+                    ('Prowlarr', '/dashboard/settings#prowlarr', integrations.prowlarr),
+                ] %}
                 <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem;">
-                    {% if integrations.discord.configured %}
-                        {% if integrations.discord.active %}
-                        <span style="color: var(--ins-color);" title="Active">●</span>
-                        {% else %}
-                        <span style="color: var(--muted-color);" title="Inactive">●</span>
-                        {% endif %}
+                    {% if info.configured and info.active %}
+                    <span style="color: var(--ins-color);" title="Active">●</span>
                     {% else %}
-                    <span style="color: var(--muted-color);" title="Not configured">●</span>
+                    <span style="color: var(--muted-color);" title="{{ 'Inactive' if info.configured else 'Not configured' }}">●</span>
                     {% endif %}
-                    <a href="/dashboard/settings#notifications" style="text-decoration: none;">Discord</a>
+                    <a href="{{ href }}" style="text-decoration: none;">{{ name }}</a>
                     <small style="color: var(--muted-color); margin-left: auto;">
-                        {% if not integrations.discord.configured %}not configured
-                        {% elif integrations.discord.active %}active
+                        {% if not info.configured %}not configured
+                        {% elif info.active %}active
                         {% else %}inactive{% endif %}
                     </small>
                 </div>
-                <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem;">
-                    {% if integrations.prowlarr.configured %}
-                        {% if integrations.prowlarr.active %}
-                        <span style="color: var(--ins-color);" title="Active">●</span>
-                        {% else %}
-                        <span style="color: var(--muted-color);" title="Inactive">●</span>
-                        {% endif %}
-                    {% else %}
-                    <span style="color: var(--muted-color);" title="Not configured">●</span>
-                    {% endif %}
-                    <a href="/dashboard/settings#prowlarr" style="text-decoration: none;">Prowlarr</a>
-                    <small style="color: var(--muted-color); margin-left: auto;">
-                        {% if not integrations.prowlarr.configured %}not configured
-                        {% elif integrations.prowlarr.active %}active
-                        {% else %}inactive{% endif %}
-                    </small>
-                </div>
+                {% endfor %}
             </div>
 
             <!-- Internal Services -->


### PR DESCRIPTION
## Summary
- Consolidate two separate grab-rate DB queries into a single query with two aggregates, matching the pattern used elsewhere in `get_dashboard_stats`
- Simplify `get_scheduler_status()` in scheduler.py with early return instead of mutable dict
- Replace duplicated Discord/Prowlarr integration rows in dashboard template with a Jinja2 `{% for %}` loop (34 lines → 18)

## Test plan
- [ ] Unit tests pass (no regressions)
- [ ] Dashboard renders correctly with all stat cards
- [ ] System Status integrations section renders identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)