### PR TITLE
fix(security): remove dead redirect param and innerHTML usage

### DIFF
--- a/src/splintarr/main.py
+++ b/src/splintarr/main.py
@@ -384,11 +384,8 @@ async def http_exception_handler(
         is_browser = "text/html" in accept and "application/json" not in accept
         is_page_request = not request.url.path.startswith("/api/")
         if is_browser or is_page_request:
-            from urllib.parse import quote
-
-            next_url = quote(str(request.url.path), safe="")
             return RedirectResponse(
-                url=f"/login?next={next_url}",
+                url="/login",
                 status_code=status.HTTP_302_FOUND,
             )
 

--- a/src/splintarr/templates/setup/admin.html
+++ b/src/splintarr/templates/setup/admin.html
@@ -101,7 +101,7 @@ function checkPasswordStrength() {
     const strengthDiv = document.getElementById('passwordStrength');
 
     if (password.length === 0) {
-        strengthDiv.innerHTML = '';
+        strengthDiv.replaceChildren();
         return;
     }
 
@@ -140,11 +140,13 @@ function checkPasswordStrength() {
         strengthClass = 'strength-strong';
     }
 
-    if (feedback.length > 0) {
-        strengthDiv.innerHTML = `<small class="${strengthClass}">Password strength: ${strengthText} (Missing: ${feedback.join(', ')})</small>`;
-    } else {
-        strengthDiv.innerHTML = `<small class="${strengthClass}">Password strength: ${strengthText}</small>`;
-    }
+    strengthDiv.replaceChildren();
+    var small = document.createElement('small');
+    small.className = strengthClass;
+    small.textContent = feedback.length > 0
+        ? 'Password strength: ' + strengthText + ' (Missing: ' + feedback.join(', ') + ')'
+        : 'Password strength: ' + strengthText;
+    strengthDiv.appendChild(small);
 }
 
 function checkPasswordMatch() {
@@ -153,15 +155,20 @@ function checkPasswordMatch() {
     const matchDiv = document.getElementById('passwordMatch');
 
     if (confirmPassword.length === 0) {
-        matchDiv.innerHTML = '';
+        matchDiv.replaceChildren();
         return;
     }
 
+    matchDiv.replaceChildren();
+    var small = document.createElement('small');
     if (password === confirmPassword) {
-        matchDiv.innerHTML = '<small style="color: var(--brand-success);">✓ Passwords match</small>';
+        small.style.color = 'var(--brand-success)';
+        small.textContent = '\u2713 Passwords match';
     } else {
-        matchDiv.innerHTML = '<small style="color: var(--brand-danger);">✗ Passwords do not match</small>';
+        small.style.color = 'var(--brand-danger)';
+        small.textContent = '\u2717 Passwords do not match';
     }
+    matchDiv.appendChild(small);
 }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
Security audit findings — no exploitable vulnerabilities, but two patterns that should be cleaned up:

- **Remove dead `?next=` redirect parameter** from the 401 exception handler in `main.py`. The parameter is built but never consumed by the login page JS, creating a latent open redirect risk if anyone wires it up without validation.
- **Replace `innerHTML` with DOM construction** in the setup admin password strength meter. Not currently exploitable (all values are from hardcoded strings), but violates the codebase-wide pattern of using `textContent` for all dynamic DOM updates.

## Security audit context
Full audit found **0 Critical, 0 High** exploitable issues. These are hardening fixes to eliminate future risk vectors.

## Test plan
- [ ] Unit tests pass
- [ ] Login redirect still works (goes to /login without ?next= param)
- [ ] Password strength meter still renders correctly on setup wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)