### PR TITLE
feat(search): live search progress and dashboard running indicator

### DIFF
--- a/src/splintarr/services/demo.py
+++ b/src/splintarr/services/demo.py
@@ -246,6 +246,8 @@ async def _run_simulation_cycle() -> None:
             "result": "found",
             "score": round(random.uniform(70, 95), 1),  # noqa: S311
             "score_reason": "missing + high priority",
+            "item_index": 1,
+            "total_items": 3,
             "demo": True,
         }),
         (20, "search.item_result", {
@@ -254,6 +256,8 @@ async def _run_simulation_cycle() -> None:
             "result": random.choice(["found", "not_found"]),  # noqa: S311
             "score": round(random.uniform(50, 80), 1),  # noqa: S311
             "score_reason": "missing + medium priority",
+            "item_index": 2,
+            "total_items": 3,
             "demo": True,
         }),
         (25, "search.item_result", {
@@ -262,6 +266,8 @@ async def _run_simulation_cycle() -> None:
             "result": "found",
             "score": round(random.uniform(60, 90), 1),  # noqa: S311
             "score_reason": "missing + low priority",
+            "item_index": 3,
+            "total_items": 3,
             "demo": True,
         }),
         (30, "search.completed", {

--- a/src/splintarr/services/search_queue.py
+++ b/src/splintarr/services/search_queue.py
@@ -691,11 +691,12 @@ class SearchQueueManager:
                 # Step 7: Truncate to max_items_per_run
                 truncated = scored_records[:max_items]
 
+                batch_total = len(truncated)
                 logger.info(
                     "search_batch_prepared",
                     strategy=strategy_name,
                     scored_count=len(scored_records),
-                    batch_size=len(truncated),
+                    batch_size=batch_total,
                     max_items=max_items,
                 )
 
@@ -771,7 +772,7 @@ class SearchQueueManager:
                 # Step 8: Search each item individually
                 # Season pack search above is an optimization; individual
                 # search serves as fallback if the pack didn't grab.
-                for record, score, reason in truncated:
+                for batch_idx, (record, score, reason) in enumerate(truncated, start=1):
                     item_id = record.get("id")
 
                     label = label_fn(record)
@@ -846,6 +847,8 @@ class SearchQueueManager:
                             "result": "found",
                             "score": score,
                             "score_reason": reason,
+                            "item_index": batch_idx,
+                            "total_items": batch_total,
                         })
                     except Exception as e:
                         errors.append(f"{item_type.title()} {item_id}: {e}")
@@ -873,6 +876,8 @@ class SearchQueueManager:
                             "result": "failed",
                             "score": score,
                             "score_reason": reason,
+                            "item_index": batch_idx,
+                            "total_items": batch_total,
                         })
 
                 # Commit library item search tracking updates

--- a/src/splintarr/static/css/custom.css
+++ b/src/splintarr/static/css/custom.css
@@ -259,3 +259,63 @@ nav[aria-label="Pagination"] a[role="button"] {
 .demo-banner-dismiss:hover {
     opacity: 1;
 }
+
+/* Search running indicator (dashboard) */
+.search-running-banner {
+    background: rgba(212, 160, 23, 0.10);
+    border: 1px solid rgba(212, 160, 23, 0.30);
+    border-radius: var(--border-radius);
+    padding: 0.5rem 1rem;
+    margin-bottom: 1.25rem;
+    display: none;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.875rem;
+    color: var(--brand-primary);
+}
+
+.search-running-banner.active {
+    display: flex;
+}
+
+.search-running-banner progress {
+    flex: 1;
+    max-width: 200px;
+}
+
+/* Live progress panel (queue detail) */
+.live-progress {
+    display: none;
+    margin-bottom: 1.5rem;
+}
+
+.live-progress.active {
+    display: block;
+}
+
+.live-progress .progress-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.live-progress .progress-header progress {
+    flex: 1;
+}
+
+.live-progress .progress-count {
+    font-size: 0.8125rem;
+    color: var(--muted-color);
+    white-space: nowrap;
+}
+
+.live-progress .results-table {
+    max-height: 300px;
+    overflow-y: auto;
+    font-size: 0.8rem;
+}
+
+.live-progress .results-table table {
+    margin: 0;
+}

--- a/src/splintarr/templates/dashboard/index.html
+++ b/src/splintarr/templates/dashboard/index.html
@@ -48,6 +48,14 @@
     </a>
 </div>
 
+<!-- Search Running Indicator (shown via WebSocket) -->
+<div class="search-running-banner" id="searchRunningBanner">
+    <span style="font-size: 1.1rem;">&#10227;</span>
+    <span id="searchRunningText">Searching...</span>
+    <progress id="searchRunningProgress"></progress>
+    <small id="searchRunningCount" style="white-space: nowrap;"></small>
+</div>
+
 <!-- Recent Activity -->
 <article>
     <header>
@@ -787,6 +795,42 @@ Splintarr.ws.on('activity.updated', function(data) {
 Splintarr.ws.on('indexer_health.updated', function() {
     refreshIndexerHealth();  // Always fetch fresh data from API
 });
+
+// Search running indicator
+(function() {
+    var banner = document.getElementById('searchRunningBanner');
+    var text = document.getElementById('searchRunningText');
+    var bar = document.getElementById('searchRunningProgress');
+    var countEl = document.getElementById('searchRunningCount');
+
+    Splintarr.ws.on('search.started', function(data) {
+        text.textContent = (data.queue_name || 'Queue') + ' \u2014 ' + (data.strategy || '');
+        bar.removeAttribute('value');
+        bar.removeAttribute('max');
+        countEl.textContent = '';
+        banner.classList.add('active');
+    });
+
+    Splintarr.ws.on('search.item_result', function(data) {
+        if (!banner.classList.contains('active')) {
+            text.textContent = 'Searching...';
+            banner.classList.add('active');
+        }
+        if (data.total_items) {
+            bar.setAttribute('max', data.total_items);
+            bar.setAttribute('value', data.item_index || 0);
+            countEl.textContent = (data.item_index || 0) + '/' + data.total_items;
+        }
+    });
+
+    Splintarr.ws.on('search.completed', function(data) {
+        banner.classList.remove('active');
+    });
+
+    Splintarr.ws.on('search.failed', function(data) {
+        banner.classList.remove('active');
+    });
+})();
 
 // WS lifecycle
 Splintarr.ws.onConnected = function() {

--- a/src/splintarr/templates/dashboard/search_queue_detail.html
+++ b/src/splintarr/templates/dashboard/search_queue_detail.html
@@ -130,6 +130,28 @@
     <a href="/dashboard/search-queues" role="button" class="secondary" style="margin-left: auto;">Back to Queues</a>
 </div>
 
+<!-- Live Progress (shown during search execution via WebSocket) -->
+<article class="live-progress" id="liveProgress">
+    <header><h3 style="color: var(--primary);">&#10227; Search In Progress</h3></header>
+    <div class="progress-header">
+        <progress id="liveProgressBar"></progress>
+        <span class="progress-count" id="liveProgressCount">Preparing...</span>
+    </div>
+    <div id="liveCurrentItem" style="margin-bottom: 0.75rem; font-size: 0.875rem; color: var(--muted-color);"></div>
+    <div class="results-table">
+        <table role="grid">
+            <thead>
+                <tr>
+                    <th>Item</th>
+                    <th data-tooltip="Search priority score">Score</th>
+                    <th>Result</th>
+                </tr>
+            </thead>
+            <tbody id="liveResultsBody"></tbody>
+        </table>
+    </div>
+</article>
+
 <!-- Execution History -->
 <article>
     <header><h3>Execution History</h3></header>
@@ -255,33 +277,100 @@
 
 {% block extra_scripts %}
 <script nonce="{{ request.state.csp_nonce }}">
-// WebSocket search progress (supplements existing polling)
+// WebSocket search progress — live progress panel
 (function() {
     if (!Splintarr.ws) return;
 
     var currentQueueId = {{ queue.id }};
+    var panel = document.getElementById('liveProgress');
+    var bar = document.getElementById('liveProgressBar');
+    var count = document.getElementById('liveProgressCount');
+    var currentItem = document.getElementById('liveCurrentItem');
+    var resultsBody = document.getElementById('liveResultsBody');
 
-    Splintarr.ws.on('search.started', function(data) {
-        if (data.queue_id != currentQueueId) return;
-        // Update UI to show execution started
+    function showRunning() {
+        panel.classList.add('active');
         var runBtn = document.querySelector('[data-action="run-now"]');
         if (runBtn) {
             runBtn.setAttribute('aria-busy', 'true');
             runBtn.disabled = true;
             runBtn.textContent = 'Running...';
         }
+    }
+
+    Splintarr.ws.on('search.started', function(data) {
+        if (data.queue_id != currentQueueId) return;
+        showRunning();
+        bar.removeAttribute('value');
+        bar.removeAttribute('max');
+        count.textContent = 'Starting ' + (data.strategy || '') + ' search...';
+        currentItem.textContent = '';
+        while (resultsBody.firstChild) resultsBody.removeChild(resultsBody.firstChild);
+    });
+
+    Splintarr.ws.on('search.item_result', function(data) {
+        if (data.queue_id != currentQueueId) return;
+        if (!panel.classList.contains('active')) showRunning();
+
+        // Update progress bar
+        if (data.total_items) {
+            bar.setAttribute('max', data.total_items);
+            bar.setAttribute('value', data.item_index || 0);
+            count.textContent = (data.item_index || 0) + ' / ' + data.total_items + ' items';
+        }
+
+        // Update current item
+        currentItem.textContent = 'Searching: ' + (data.item_name || '');
+
+        // Append result row
+        var tr = document.createElement('tr');
+
+        var tdItem = document.createElement('td');
+        tdItem.textContent = data.item_name || '';
+        tr.appendChild(tdItem);
+
+        var tdScore = document.createElement('td');
+        if (data.score != null) {
+            tdScore.textContent = data.score;
+            if (data.score_reason) tdScore.setAttribute('title', data.score_reason);
+        } else {
+            tdScore.textContent = '-';
+            tdScore.style.color = 'var(--muted-color)';
+        }
+        tr.appendChild(tdScore);
+
+        var tdResult = document.createElement('td');
+        if (data.result === 'found') {
+            tdResult.style.color = 'var(--ins-color)';
+            tdResult.textContent = '\u2713 sent';
+        } else if (data.result === 'failed') {
+            tdResult.style.color = 'var(--del-color)';
+            tdResult.textContent = '\u2717 error';
+        } else {
+            tdResult.style.color = 'var(--muted-color)';
+            tdResult.textContent = '\u2014 ' + (data.result || 'unknown');
+        }
+        tr.appendChild(tdResult);
+
+        resultsBody.appendChild(tr);
     });
 
     Splintarr.ws.on('search.completed', function(data) {
         if (data.queue_id != currentQueueId) return;
-        // Refresh the page to show results
-        window.location.reload();
+        var maxVal = parseInt(bar.getAttribute('max'), 10) || data.items_searched || 0;
+        if (maxVal > 0) {
+            bar.setAttribute('max', maxVal);
+            bar.setAttribute('value', maxVal);
+        }
+        count.textContent = 'Complete \u2014 ' + (data.items_searched || 0) + ' searched, ' + (data.items_found || 0) + ' found';
+        currentItem.textContent = '';
+        setTimeout(function() { window.location.reload(); }, 1500);
     });
 
     Splintarr.ws.on('search.failed', function(data) {
         if (data.queue_id != currentQueueId) return;
         Splintarr.showNotification('Search failed: ' + (data.error || 'Unknown error'), 'error');
-        window.location.reload();
+        setTimeout(function() { window.location.reload(); }, 1500);
     });
 })();
 
@@ -360,11 +449,11 @@ async function confirmRunNow() {
                 runBtn.disabled = true;
                 runBtn.textContent = 'Running...';
             }
-            pollQueueStatus(_runNowQueueId);
+            if (!Splintarr.ws || !Splintarr.ws.connected) pollQueueStatus(_runNowQueueId);
         } else if (response.status === 409) {
             document.getElementById('run-now-dialog').close();
             showNotification('Search is already running');
-            pollQueueStatus(_runNowQueueId);
+            if (!Splintarr.ws || !Splintarr.ws.connected) pollQueueStatus(_runNowQueueId);
         } else {
             showNotification('Failed to start: ' + (data.detail || 'Unknown error'));
         }
@@ -392,11 +481,16 @@ function pollQueueStatus(queueId) {
     }, 3000);
 }
 
-// Auto-poll if page loads while queue is in_progress
+// Auto-show live progress if page loads while queue is in_progress
 (function() {
     var btn = document.querySelector('[data-action="run-now"]');
     if (btn && btn.disabled) {
-        pollQueueStatus({{ queue.id }});
+        var panel = document.getElementById('liveProgress');
+        if (panel) {
+            panel.classList.add('active');
+            document.getElementById('liveProgressCount').textContent = 'Search in progress...';
+        }
+        if (!Splintarr.ws || !Splintarr.ws.connected) pollQueueStatus({{ queue.id }});
     }
 })();
 


### PR DESCRIPTION
## Summary
- Live Progress panel on queue detail page: progress bar, current item, streaming results table with scores
- Gold "currently running" banner on dashboard with queue name and item count
- Enriched `search.item_result` WS events with `item_index` and `total_items` for determinate progress bars
- Uses `enumerate`-based loop counter instead of `items_searched` to avoid count inflation from rate limits and season packs

## Files changed (5)
- `services/search_queue.py` — `batch_total`, `batch_idx` via enumerate, enriched event emissions
- `services/demo.py` — matching `item_index`/`total_items` on demo events
- `templates/dashboard/search_queue_detail.html` — Live Progress panel + WS handlers
- `templates/dashboard/index.html` — Running indicator banner + WS handlers
- `static/css/custom.css` — `.search-running-banner` and `.live-progress` styles

## Test plan
- [x] 74 related unit tests pass (demo shapes, scoring, search queue bugs)
- [x] Lint clean (ruff)
- [x] Three-way result display: found=green, failed=red, other=muted
- [x] Progress bar: indeterminate on search.started, determinate on first item_result
- [x] Poll fallback guarded with WS connection check
- [ ] E2E: Run a search queue, verify live progress panel appears and streams results
- [ ] E2E: Verify dashboard running banner appears during search execution
- [ ] E2E: Verify page reloads after completion with new history entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)