### PR TITLE
feat(search): dry run preview for search queues

### DIFF
--- a/src/splintarr/api/search_queue.py
+++ b/src/splintarr/api/search_queue.py
@@ -483,6 +483,7 @@ async def preview_search_queue(
     current_user: User = Depends(get_current_user),
 ) -> Any:
     """Preview what would be searched in the next run."""
+    logger.debug("search_queue_preview_requested", queue_id=queue_id, user_id=current_user.id)
     try:
         _get_user_queue(db, queue_id, current_user.id)
         queue_manager = SearchQueueManager(get_session_factory())
@@ -492,7 +493,8 @@ async def preview_search_queue(
     except SearchQueueError as e:
         logger.warning("search_queue_preview_failed", error=str(e), queue_id=queue_id)
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Preview failed — queue configuration error",
         ) from None
     except Exception as e:
         logger.error("search_queue_preview_error", error=str(e), queue_id=queue_id)

--- a/src/splintarr/services/search_queue.py
+++ b/src/splintarr/services/search_queue.py
@@ -1050,6 +1050,8 @@ class SearchQueueManager:
             queue = db.query(SearchQueue).filter(SearchQueue.id == queue_id).first()
             if not queue:
                 raise SearchQueueError(f"Queue {queue_id} not found")
+            if not queue.is_active:
+                raise SearchQueueError(f"Queue {queue_id} is paused")
 
             instance = db.query(Instance).filter(Instance.id == queue.instance_id).first()
             if not instance:
@@ -1065,6 +1067,13 @@ class SearchQueueManager:
             fetch_method, strategy_name, sort_key, sort_dir = self._get_strategy_params(
                 queue, instance
             )
+
+            # Validate custom strategy filters (same check as _execute_custom_strategy)
+            if queue.strategy == "custom" and queue.filters:
+                try:
+                    json.loads(queue.filters)
+                except json.JSONDecodeError as err:
+                    raise SearchQueueError("Invalid custom filters JSON") from err
 
             is_sonarr = instance.instance_type == "sonarr"
             max_items = getattr(queue, "max_items_per_run", 50) or 50

--- a/src/splintarr/templates/dashboard/search_queue_detail.html
+++ b/src/splintarr/templates/dashboard/search_queue_detail.html
@@ -546,10 +546,11 @@ async function previewQueue(queueId) {
 
     try {
         var response = await fetch('/api/search-queues/' + queueId + '/preview', { method: 'POST' });
-        var data = await response.json();
+        var data = {};
+        try { data = await response.json(); } catch (_) {}
 
         if (!response.ok) {
-            showNotification('Preview failed: ' + (data.detail || 'Unknown error'), 'error');
+            showNotification('Preview failed: ' + (data.detail || 'Server error (' + response.status + ')'), 'error');
             return;
         }
 


### PR DESCRIPTION
## Summary
- "Preview Next Run" button on queue detail page runs the full scoring/filtering pipeline without executing searches
- Shows what would be searched: items in priority order with scores and reasons
- Summary stats: eligible -> excluded -> cooldown -> scored -> batch size
- Season pack groupings shown when enabled
- New `POST /api/search-queues/{id}/preview` endpoint (5/min rate limit)

## Files changed (3)
- `services/search_queue.py` — `preview_queue()` method + `_get_strategy_params()` helper (200 lines)
- `api/search_queue.py` — `/preview` endpoint with ownership check and error handling (33 lines)
- `templates/dashboard/search_queue_detail.html` — Preview button + results panel with JS handler (122 lines)

## Test plan
- [x] 103 related unit tests pass (scoring, cooldown, search queue bugs, demo shapes)
- [x] Lint clean (ruff — only pre-existing B904 warnings remain)
- [ ] E2E: Click Preview on a queue with a connected instance, verify items appear with scores
- [ ] E2E: Verify season pack groupings shown when enabled
- [ ] E2E: Verify error handling when instance is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)