### PR TITLE
feat(dashboard): Last 7 Days analytics card with trends

### DIFF
--- a/src/splintarr/api/dashboard.py
+++ b/src/splintarr/api/dashboard.py
@@ -1332,6 +1332,113 @@ async def api_dashboard_system_status(
     )
 
 
+@router.get("/api/dashboard/analytics", include_in_schema=False)
+@limiter.limit("30/minute")
+async def api_dashboard_analytics(
+    request: Request,
+    current_user: User = Depends(get_current_user_from_cookie),
+    db: Session = Depends(get_db),
+) -> JSONResponse:
+    """Last 7 days analytics with trend comparison vs prior 7 days."""
+    if is_demo_active(db, current_user.id):
+        from splintarr.services.demo import get_demo_analytics
+
+        logger.debug("dashboard_analytics_demo", user_id=current_user.id)
+        return JSONResponse(content=get_demo_analytics())
+
+    logger.debug("dashboard_analytics_requested", user_id=current_user.id)
+
+    now = datetime.utcnow()
+    current_start = now - timedelta(days=7)
+    previous_start = now - timedelta(days=14)
+
+    def _period_stats(start: datetime, end: datetime) -> dict[str, int]:
+        row = (
+            db.query(
+                func.count(SearchHistory.id).label("searches"),
+                func.coalesce(func.sum(SearchHistory.items_found), 0).label("items_found"),
+                func.coalesce(func.sum(SearchHistory.searches_triggered), 0).label("grabs"),
+            )
+            .join(Instance)
+            .filter(
+                Instance.user_id == current_user.id,
+                SearchHistory.started_at >= start,
+                SearchHistory.started_at < end,
+            )
+            .one()
+        )
+        return {
+            "searches": row.searches or 0,
+            "items_found": int(row.items_found),
+            "grabs": int(row.grabs),
+        }
+
+    current = _period_stats(current_start, now)
+    previous = _period_stats(previous_start, current_start)
+
+    # Trend percentages (positive = improvement)
+    def _trend(cur: int, prev: int) -> float:
+        if prev == 0:
+            return 100.0 if cur > 0 else 0.0
+        return round((cur - prev) / prev * 100, 1)
+
+    trends = {
+        "searches": _trend(current["searches"], previous["searches"]),
+        "items_found": _trend(current["items_found"], previous["items_found"]),
+        "grabs": _trend(current["grabs"], previous["grabs"]),
+    }
+
+    # Top 3 most-searched series (from search_metadata JSON in last 7 days)
+    top_series: list[dict[str, Any]] = []
+    history_rows = (
+        db.query(SearchHistory.search_metadata)
+        .join(Instance)
+        .filter(
+            Instance.user_id == current_user.id,
+            SearchHistory.started_at >= current_start,
+            SearchHistory.search_metadata.isnot(None),
+        )
+        .all()
+    )
+
+    series_counts: dict[str, int] = {}
+    for (metadata_json,) in history_rows:
+        try:
+            entries = json.loads(metadata_json) if metadata_json else []
+        except (json.JSONDecodeError, TypeError):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            item_name = entry.get("item", "")
+            # Extract series name: "Breaking Bad S01E01 - Pilot" -> "Breaking Bad"
+            if " S" in item_name and "E" in item_name:
+                series_name = item_name.split(" S")[0]
+            elif " - " in item_name:
+                series_name = item_name.split(" - ")[0].strip()
+            else:
+                series_name = item_name
+            if series_name:
+                series_counts[series_name] = series_counts.get(series_name, 0) + 1
+
+    sorted_series = sorted(series_counts.items(), key=lambda x: x[1], reverse=True)[:3]
+    top_series = [{"title": name, "search_count": count} for name, count in sorted_series]
+
+    logger.debug(
+        "dashboard_analytics_completed",
+        user_id=current_user.id,
+        current_searches=current["searches"],
+        top_series_count=len(top_series),
+    )
+
+    return JSONResponse(content={
+        "current": current,
+        "previous": previous,
+        "trends": trends,
+        "top_series": top_series,
+    })
+
+
 @router.get("/api/dashboard/indexer-health", include_in_schema=False)
 @limiter.limit("30/minute")
 async def api_indexer_health(

--- a/src/splintarr/services/demo.py
+++ b/src/splintarr/services/demo.py
@@ -207,6 +207,21 @@ def get_demo_indexer_health() -> dict[str, Any]:
     }
 
 
+def get_demo_analytics() -> dict[str, Any]:
+    """Synthetic analytics matching ``/api/dashboard/analytics`` shape."""
+    return {
+        "current": {"searches": 34, "items_found": 12, "grabs": 5},
+        "previous": {"searches": 22, "items_found": 8, "grabs": 3},
+        "trends": {"searches": 54.5, "items_found": 50.0, "grabs": 66.7},
+        "top_series": [
+            {"title": "Breaking Bad", "search_count": 8},
+            {"title": "The Wire", "search_count": 5},
+            {"title": "Severance", "search_count": 3},
+        ],
+        "demo": True,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Simulation loop
 # ---------------------------------------------------------------------------

--- a/src/splintarr/templates/dashboard/index.html
+++ b/src/splintarr/templates/dashboard/index.html
@@ -125,6 +125,34 @@
     </footer>
 </article>
 
+<!-- Last 7 Days Analytics -->
+<article id="analytics-card">
+    <header>
+        <h3>Last 7 Days</h3>
+    </header>
+    <div class="grid" id="analytics-metrics" style="text-align: center;">
+        <div>
+            <div id="analytics-searches" style="font-size: 1.5rem; font-weight: 700; color: var(--primary);">-</div>
+            <small style="color: var(--muted-color); text-transform: uppercase; font-size: 0.6875rem; letter-spacing: 0.5px;">Searches Run</small>
+            <div id="analytics-searches-trend" style="font-size: 0.75rem;"></div>
+        </div>
+        <div>
+            <div id="analytics-found" style="font-size: 1.5rem; font-weight: 700; color: var(--primary);">-</div>
+            <small style="color: var(--muted-color); text-transform: uppercase; font-size: 0.6875rem; letter-spacing: 0.5px;">Items Found</small>
+            <div id="analytics-found-trend" style="font-size: 0.75rem;"></div>
+        </div>
+        <div>
+            <div id="analytics-grabs" style="font-size: 1.5rem; font-weight: 700; color: var(--primary);">-</div>
+            <small style="color: var(--muted-color); text-transform: uppercase; font-size: 0.6875rem; letter-spacing: 0.5px;">Grabs Confirmed</small>
+            <div id="analytics-grabs-trend" style="font-size: 0.75rem;"></div>
+        </div>
+    </div>
+    <div id="analytics-top-series" style="display: none; margin-top: 0.75rem; border-top: 1px solid var(--muted-border-color); padding-top: 0.75rem;">
+        <small style="color: var(--muted-color); text-transform: uppercase; font-size: 0.7rem; letter-spacing: 0.05em;">Most Searched</small>
+        <div id="analytics-top-series-list" style="margin-top: 0.25rem;"></div>
+    </div>
+</article>
+
 <!-- Indexer Health (only shown if Prowlarr configured) -->
 <div id="indexer-health-section" style="display: none;">
     <article>
@@ -760,14 +788,76 @@ function updateSystemStatusDOM(data) {
 // Polling fallback management
 var pollingTimers = [];
 
+// Analytics
+async function refreshAnalytics() {
+    try {
+        var response = await fetch('/api/dashboard/analytics');
+        if (!response.ok) return;
+        var data = await response.json();
+        updateAnalyticsDOM(data);
+    } catch (e) {}
+}
+
+function updateAnalyticsDOM(data) {
+    document.getElementById('analytics-searches').textContent = data.current.searches;
+    document.getElementById('analytics-found').textContent = data.current.items_found;
+    document.getElementById('analytics-grabs').textContent = data.current.grabs;
+
+    function renderTrend(el, pct) {
+        if (pct > 0) {
+            el.style.color = 'var(--ins-color)';
+            el.textContent = '\u25B2 +' + pct + '% vs prior 7d';
+        } else if (pct < 0) {
+            el.style.color = 'var(--del-color)';
+            el.textContent = '\u25BC ' + pct + '% vs prior 7d';
+        } else {
+            el.style.color = 'var(--muted-color)';
+            el.textContent = '\u2014 no change';
+        }
+    }
+
+    renderTrend(document.getElementById('analytics-searches-trend'), data.trends.searches);
+    renderTrend(document.getElementById('analytics-found-trend'), data.trends.items_found);
+    renderTrend(document.getElementById('analytics-grabs-trend'), data.trends.grabs);
+
+    // Top series
+    var section = document.getElementById('analytics-top-series');
+    var list = document.getElementById('analytics-top-series-list');
+    while (list.firstChild) list.removeChild(list.firstChild);
+    if (data.top_series && data.top_series.length > 0) {
+        section.style.display = 'block';
+        data.top_series.forEach(function(s, i) {
+            var div = document.createElement('div');
+            div.style.fontSize = '0.8125rem';
+            div.style.padding = '0.125rem 0';
+            var num = document.createElement('span');
+            num.style.color = 'var(--muted-color)';
+            num.textContent = (i + 1) + '. ';
+            div.appendChild(num);
+            var name = document.createTextNode(s.title);
+            div.appendChild(name);
+            var count = document.createElement('span');
+            count.style.color = 'var(--muted-color)';
+            count.style.marginLeft = '0.5rem';
+            count.textContent = '(' + s.search_count + ')';
+            div.appendChild(count);
+            list.appendChild(div);
+        });
+    } else {
+        section.style.display = 'none';
+    }
+}
+
 function startPolling() {
     stopPolling();
     pollingTimers.push(setInterval(pollStats, 30000));
     pollingTimers.push(setInterval(pollSystemStatus, 30000));
     pollingTimers.push(setInterval(pollActivity, 15000));
     pollingTimers.push(setInterval(refreshIndexerHealth, 60000));
+    pollingTimers.push(setInterval(refreshAnalytics, 60000));
     pollActivity();
     refreshIndexerHealth();
+    refreshAnalytics();
 }
 
 function stopPolling() {
@@ -779,6 +869,7 @@ function stopPolling() {
 Splintarr.ws.on('stats.updated', function(data) {
     if (data && data.search_queues) updateDashboardStats(data);
     else pollStats();  // Empty payload = trigger a fetch
+    refreshAnalytics();  // Analytics may have changed too
 });
 
 Splintarr.ws.on('status.updated', function(data) {
@@ -840,6 +931,7 @@ Splintarr.ws.onConnected = function() {
     pollSystemStatus();
     pollActivity();
     refreshIndexerHealth();
+    refreshAnalytics();
 };
 
 Splintarr.ws.onFallback = startPolling;

--- a/tests/unit/test_demo.py
+++ b/tests/unit/test_demo.py
@@ -233,6 +233,38 @@ class TestDemoIndexerHealth:
         assert len(disabled) >= 1
 
 
+class TestDemoAnalytics:
+    """Verify get_demo_analytics matches /api/dashboard/analytics shape."""
+
+    def test_shape(self):
+        from splintarr.services.demo import get_demo_analytics
+
+        data = get_demo_analytics()
+        assert "current" in data
+        assert "previous" in data
+        assert "trends" in data
+        assert "top_series" in data
+        assert data["demo"] is True
+
+    def test_period_keys(self):
+        from splintarr.services.demo import get_demo_analytics
+
+        data = get_demo_analytics()
+        for period in ["current", "previous"]:
+            assert "searches" in data[period]
+            assert "items_found" in data[period]
+            assert "grabs" in data[period]
+
+    def test_top_series_structure(self):
+        from splintarr.services.demo import get_demo_analytics
+
+        data = get_demo_analytics()
+        assert len(data["top_series"]) == 3
+        for s in data["top_series"]:
+            assert "title" in s
+            assert "search_count" in s
+
+
 # ---------------------------------------------------------------------------
 # Simulation lifecycle tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New "Last 7 Days" analytics card on dashboard with week-over-week trend comparison
- Three metrics: Searches Run, Items Found, Grabs Confirmed — with colored trend arrows
- Top 3 most-searched series extracted from search_metadata JSON
- Demo mode support with synthetic analytics data
- Refreshes on stats.updated WS events

## Files changed (4)
- `api/dashboard.py` — new `/api/dashboard/analytics` endpoint with period queries + series extraction
- `services/demo.py` — `get_demo_analytics()` generator
- `templates/dashboard/index.html` — analytics card HTML + JS (fetch, render, WS wiring)
- `tests/unit/test_demo.py` — 3 new shape tests for demo analytics

## Test plan
- [x] 22 unit tests pass (19 existing + 3 new analytics shape tests)
- [x] Lint clean
- [ ] E2E: Verify analytics card renders with demo data
- [ ] E2E: Verify trend arrows show correct colors (green up, red down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)