### PR TITLE
feat(queues): bulk queue operations

### DIFF
--- a/src/splintarr/static/css/custom.css
+++ b/src/splintarr/static/css/custom.css
@@ -319,3 +319,22 @@ nav[aria-label="Pagination"] a[role="button"] {
 .live-progress .results-table table {
     margin: 0;
 }
+
+/* Bulk actions bar (queues page) */
+.bulk-actions-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
+    background: var(--card-background-color);
+    border: 1px solid var(--muted-border-color);
+    border-radius: var(--border-radius);
+    font-size: 0.875rem;
+}
+
+.bulk-actions-bar button {
+    padding: 0.375rem 0.75rem;
+    font-size: 0.8125rem;
+    margin: 0;
+}

--- a/src/splintarr/templates/dashboard/search_queues.html
+++ b/src/splintarr/templates/dashboard/search_queues.html
@@ -12,13 +12,30 @@
     <a href="#create-queue" role="button">+ Create Queue</a>
 </div>
 
+<!-- Bulk Actions Bar -->
+{% if queues %}
+<div class="bulk-actions-bar" id="bulkActionsBar">
+    <label style="display: flex; align-items: center; gap: 0.5rem; margin: 0; cursor: pointer;">
+        <input type="checkbox" id="selectAllQueues">
+        <span id="bulkSelectionCount">0 selected</span>
+    </label>
+    <div style="display: flex; gap: 0.5rem; margin-left: auto;">
+        <button class="secondary" data-bulk="pause" disabled>Pause</button>
+        <button class="secondary" data-bulk="resume" disabled>Resume</button>
+        <button data-bulk="run" disabled>Run Now</button>
+        <button class="secondary" style="color: var(--del-color);" data-bulk="delete" disabled>Delete</button>
+    </div>
+</div>
+{% endif %}
+
 <!-- Queues List -->
 {% if queues %}
 <div class="grid">
     {% for queue in queues %}
     <article>
         <header>
-            <h3>
+            <h3 style="display: flex; align-items: center; gap: 0.5rem;">
+                <input type="checkbox" class="queue-select" data-queue-id="{{ queue.id }}" data-queue-name="{{ queue.name }}" style="margin: 0;">
                 <a href="/dashboard/search-queues/{{ queue.id }}" style="text-decoration: none; color: inherit;">{{ queue.name }}</a>
                 {% if not queue.is_active %}
                 <small style="color: var(--muted-color);">⏸ Paused</small>
@@ -736,5 +753,104 @@ document.querySelector('a[href="#create-queue"]').addEventListener('click', func
     applyPreset('weekly-cutoff');
     document.getElementById('create-queue').showModal();
 });
+
+// ======================================================================
+// Bulk Queue Operations
+// ======================================================================
+(function() {
+    var selectAll = document.getElementById('selectAllQueues');
+    var countLabel = document.getElementById('bulkSelectionCount');
+    var checkboxes = document.querySelectorAll('.queue-select');
+    var bulkButtons = document.querySelectorAll('[data-bulk]');
+
+    if (!selectAll || checkboxes.length === 0) return;
+
+    function getSelectedIds() {
+        var ids = [];
+        checkboxes.forEach(function(cb) { if (cb.checked) ids.push(parseInt(cb.dataset.queueId)); });
+        return ids;
+    }
+
+    function getSelectedNames() {
+        var names = [];
+        checkboxes.forEach(function(cb) { if (cb.checked) names.push(cb.dataset.queueName); });
+        return names;
+    }
+
+    function updateBulkUI() {
+        var selected = getSelectedIds();
+        var n = selected.length;
+        countLabel.textContent = n + ' selected';
+        bulkButtons.forEach(function(btn) { btn.disabled = n === 0; });
+        selectAll.checked = n === checkboxes.length && n > 0;
+        selectAll.indeterminate = n > 0 && n < checkboxes.length;
+    }
+
+    selectAll.addEventListener('change', function() {
+        checkboxes.forEach(function(cb) { cb.checked = selectAll.checked; });
+        updateBulkUI();
+    });
+
+    checkboxes.forEach(function(cb) {
+        cb.addEventListener('change', updateBulkUI);
+    });
+
+    async function bulkAction(action, ids) {
+        var results = { ok: 0, fail: 0 };
+        for (var i = 0; i < ids.length; i++) {
+            try {
+                var url = '/api/search-queues/' + ids[i] + '/' + action;
+                var method = action === 'delete' ? 'DELETE' : 'POST';
+                if (action === 'delete') url = '/api/search-queues/' + ids[i];
+                var response = await fetch(url, { method: method });
+                if (response.ok) results.ok++;
+                else results.fail++;
+            } catch (e) {
+                results.fail++;
+            }
+        }
+        return results;
+    }
+
+    document.addEventListener('click', function(e) {
+        var btn = e.target.closest('[data-bulk]');
+        if (!btn || btn.disabled) return;
+
+        var action = btn.dataset.bulk;
+        var ids = getSelectedIds();
+        if (ids.length === 0) return;
+
+        if (action === 'pause') {
+            if (!confirm('Pause ' + ids.length + ' queue(s)?')) return;
+            btn.setAttribute('aria-busy', 'true');
+            bulkAction('pause', ids).then(function(r) {
+                Splintarr.showNotification(r.ok + ' paused' + (r.fail ? ', ' + r.fail + ' failed' : ''), r.fail ? 'error' : 'success');
+                location.reload();
+            });
+        } else if (action === 'resume') {
+            if (!confirm('Resume ' + ids.length + ' queue(s)?')) return;
+            btn.setAttribute('aria-busy', 'true');
+            bulkAction('resume', ids).then(function(r) {
+                Splintarr.showNotification(r.ok + ' resumed' + (r.fail ? ', ' + r.fail + ' failed' : ''), r.fail ? 'error' : 'success');
+                location.reload();
+            });
+        } else if (action === 'run') {
+            if (!confirm('Run ' + ids.length + ' queue(s) now?')) return;
+            btn.setAttribute('aria-busy', 'true');
+            bulkAction('start', ids).then(function(r) {
+                Splintarr.showNotification(r.ok + ' started' + (r.fail ? ', ' + r.fail + ' failed' : ''), r.fail ? 'error' : 'success');
+                location.reload();
+            });
+        } else if (action === 'delete') {
+            var names = getSelectedNames();
+            if (!confirm('Delete ' + ids.length + ' queue(s)?\n\n' + names.join('\n'))) return;
+            btn.setAttribute('aria-busy', 'true');
+            bulkAction('delete', ids).then(function(r) {
+                Splintarr.showNotification(r.ok + ' deleted' + (r.fail ? ', ' + r.fail + ' failed' : ''), r.fail ? 'error' : 'success');
+                location.reload();
+            });
+        }
+    });
+})();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Multi-select checkboxes on queue cards with bulk action bar
- Bulk Pause, Resume, Run Now, Delete with confirmation dialogs
- Select All with indeterminate state, selection count indicator
- Pure frontend — calls existing per-queue API endpoints sequentially
- Page reload with success/failure toast notification

## Files changed (2)
- `templates/dashboard/search_queues.html` — checkboxes in card headers, bulk actions bar, JS handlers (120 lines)
- `static/css/custom.css` — `.bulk-actions-bar` styles (16 lines)

## Test plan
- [x] 22 unit tests pass
- [ ] E2E: Select multiple queues, verify bulk actions bar enables
- [ ] E2E: Select All / deselect, verify indeterminate state
- [ ] E2E: Bulk pause/resume/delete with confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)