### PR TITLE
fix: update checker UX — distinguish failure from up-to-date

### DIFF
--- a/src/splintarr/api/updates.py
+++ b/src/splintarr/api/updates.py
@@ -46,6 +46,7 @@ async def update_status(
         **state,
         "current_version": __version__,
         "update_available": is_update_available(__version__, latest) if latest else False,
+        "check_succeeded": bool(latest),
     })
 
 
@@ -63,6 +64,7 @@ async def check_now(
         **state,
         "current_version": __version__,
         "update_available": is_update_available(__version__, latest) if latest else False,
+        "check_succeeded": bool(latest),
     })
 
 

--- a/src/splintarr/services/update_checker.py
+++ b/src/splintarr/services/update_checker.py
@@ -17,7 +17,7 @@ from splintarr import __version__
 logger = structlog.get_logger()
 
 GITHUB_RELEASES_URL = "https://api.github.com/repos/menottim/splintarr/releases/latest"
-REQUEST_TIMEOUT = 5.0
+REQUEST_TIMEOUT = 10.0
 
 # Module-level cache (same pattern as _sync_state in api/library.py)
 _update_state: dict[str, Any] = {}

--- a/src/splintarr/templates/dashboard/settings.html
+++ b/src/splintarr/templates/dashboard/settings.html
@@ -939,7 +939,10 @@ document.getElementById('checkNowBtn').addEventListener('click', async function(
         const response = await fetch('/api/updates/check', { method: 'POST' });
         const data = await response.json();
         status.style.display = 'inline';
-        if (data.update_available) {
+        if (!data.check_succeeded) {
+            status.textContent = 'Check failed \u2014 GitHub may be unreachable.';
+            status.style.color = 'var(--del-color)';
+        } else if (data.update_available) {
             status.textContent = 'Update available: v' + data.latest_version;
             status.style.color = 'var(--brand-primary)';
         } else {

--- a/tests/unit/test_updates_api.py
+++ b/tests/unit/test_updates_api.py
@@ -75,6 +75,7 @@ class TestUpdateStatusEndpoint:
         assert data["checked_at"] == "2026-03-03T00:00:00+00:00"
         assert data["current_version"] is not None
         assert data["update_available"] is True
+        assert data["check_succeeded"] is True
 
     def test_no_update_available(self, authed_client: TestClient):
         """Status endpoint returns update_available=False when versions match."""
@@ -91,6 +92,7 @@ class TestUpdateStatusEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert data["update_available"] is False
+        assert data["check_succeeded"] is True
 
     def test_no_latest_version(self, authed_client: TestClient):
         """Status endpoint handles empty state (no check done yet)."""
@@ -101,6 +103,7 @@ class TestUpdateStatusEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert data["update_available"] is False
+        assert data["check_succeeded"] is False
         assert "current_version" in data
 
     def test_requires_auth(self, client: TestClient):
@@ -129,6 +132,18 @@ class TestCheckNowEndpoint:
         data = response.json()
         assert data["latest_version"] == "2.0.0"
         assert data["update_available"] is True
+        assert data["check_succeeded"] is True
+
+    def test_check_failure_returns_check_succeeded_false(self, authed_client: TestClient):
+        """Check endpoint returns check_succeeded=False when GitHub is unreachable."""
+        with patch("splintarr.api.updates.check_for_updates", new_callable=AsyncMock,
+                    return_value={}):
+            response = authed_client.post("/api/updates/check")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["check_succeeded"] is False
+        assert data["update_available"] is False
 
     def test_check_requires_auth(self, client: TestClient):
         """Check endpoint requires authentication."""


### PR DESCRIPTION
## Summary

- **Bug fix**: "Check Now" button in Settings showed "You are running the latest version" (green) when the GitHub API check actually failed (timeout/rate limit). Now correctly shows "Check failed — GitHub may be unreachable" (red).
- **Optimization**: Increased GitHub API timeout from 5s to 10s for Docker environments where DNS resolution can be slow.

## Root Cause

The `/api/updates/check` endpoint returned `update_available: false` with no way to distinguish "check succeeded, no update" from "check failed, no data". The JS only checked `update_available`, treating both cases as "up to date".

## Fix

Added `check_succeeded: bool` field to both `/api/updates/status` and `/api/updates/check` responses. The JS now checks `check_succeeded` first and shows an error message when false.

## Changes

- `src/splintarr/api/updates.py` — Add `check_succeeded` field to status and check responses
- `src/splintarr/services/update_checker.py` — Increase timeout 5s → 10s
- `src/splintarr/templates/dashboard/settings.html` — Check `check_succeeded` before showing result
- `tests/unit/test_updates_api.py` — Add test for failure case, assert `check_succeeded` in existing tests

## Test Plan

- [x] 38 tests passing (37 existing + 1 new failure case test)
- [x] E2E verified: "Check Now" shows red error when GitHub unreachable from Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)