### PR TITLE
fix: resolve 'Unknown' series in Most Searched analytics

### DIFF
--- a/src/splintarr/api/dashboard.py
+++ b/src/splintarr/api/dashboard.py
@@ -1429,8 +1429,11 @@ async def api_dashboard_analytics(
                 continue
             item_name = entry.get("item", "")
             # Extract series name: "Breaking Bad S01E01 - Pilot" -> "Breaking Bad"
-            if " S" in item_name and "E" in item_name:
-                series_name = item_name.split(" S")[0]
+            # Use regex to find the actual SxxExx pattern, not naive split on " S"
+            # which breaks titles containing " S" (e.g., "Unknown Series", "The Simpsons")
+            season_match = re.search(r"\sS\d{1,3}E\d{1,4}", item_name)
+            if season_match:
+                series_name = item_name[:season_match.start()]
             elif " - " in item_name:
                 series_name = item_name.split(" - ")[0].strip()
             else:

--- a/src/splintarr/services/base_client.py
+++ b/src/splintarr/services/base_client.py
@@ -493,6 +493,7 @@ class BaseArrClient:
             "pageSize": min(page_size, 100),
             "sortKey": sort_key or self._wanted_missing_sort_key,
             "sortDirection": sort_dir or self._wanted_missing_sort_dir,
+            "includeSeries": "true",
         }
 
         result = await self._request("GET", "/api/v3/wanted/missing", params=params)
@@ -530,6 +531,7 @@ class BaseArrClient:
             "pageSize": min(page_size, 100),
             "sortKey": sort_key or self._wanted_cutoff_sort_key,
             "sortDirection": sort_dir or self._wanted_cutoff_sort_dir,
+            "includeSeries": "true",
         }
 
         result = await self._request("GET", "/api/v3/wanted/cutoff", params=params)

--- a/tests/unit/test_sonarr_client.py
+++ b/tests/unit/test_sonarr_client.py
@@ -267,6 +267,7 @@ class TestSonarrAPIRequests:
                     "pageSize": 50,
                     "sortKey": "airDateUtc",
                     "sortDirection": "descending",
+                    "includeSeries": "true",
                 },
             )
 
@@ -299,6 +300,7 @@ class TestSonarrAPIRequests:
                     "pageSize": 50,
                     "sortKey": "airDateUtc",
                     "sortDirection": "descending",
+                    "includeSeries": "true",
                 },
             )
 


### PR DESCRIPTION
## Summary

- **Add `includeSeries=true`** to Sonarr wanted/missing and wanted/cutoff API calls so episode records include nested series data
- **Fix regex-based series extraction** in analytics — replace naive `split(" S")` with `re.search(r"\sS\d{1,3}E\d{1,4}")` to correctly handle titles containing capital-S words

## Root Cause

Two compounding bugs:
1. Sonarr API calls missing `includeSeries=true` → episodes fell back to "Unknown Series"
2. Analytics `split(" S")[0]` on "Unknown **S**eries S01E01" → "Unknown" (split on wrong " S")

Also affected titles like "The Simpsons", "S.W.A.T.", etc.

## Files Changed

| File | Change |
|------|--------|
| `services/base_client.py` | `includeSeries=true` on both wanted endpoints |
| `api/dashboard.py` | Regex-based series name extraction |
| `tests/unit/test_sonarr_client.py` | Updated expected params in 2 tests |

## Test plan

- [ ] `pytest tests/unit/test_sonarr_client.py::TestSonarrAPIRequests` passes
- [ ] Run a search, check dashboard analytics shows real series names
- [ ] Existing "Unknown" entries will age out of the 7-day window naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)