### PR TITLE
Restore subtle ambient animations on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,12 @@
         radial-gradient(ellipse at 80% 80%, var(--gold-glow) 0%, transparent 50%);
       pointer-events: none;
       z-index: -1;
+      animation: drift 60s ease-in-out infinite alternate;
+    }
+
+    @keyframes drift {
+      from { transform: translate(0, 0); }
+      to { transform: translate(-2%, 1%); }
     }
 
     /* --- Noise texture overlay --- */
@@ -182,6 +188,12 @@
       height: 6px;
       background: var(--green);
       border-radius: 50%;
+      animation: pulse-dot 3s ease-in-out infinite;
+    }
+
+    @keyframes pulse-dot {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
     }
 
     .hero h1 {


### PR DESCRIPTION
## Summary
- Restore background gradient drift at 60s cycle (was 20s) with 2% travel (was 3%) — barely perceptible ambient motion
- Restore hero badge pulsing dot at 3s cycle (was 2s) with gentler fade (50% vs 40%)
- Scroll-triggered section fade-ins remain removed from previous PR

## Test plan
- [ ] Verify background has very slow, subtle movement
- [ ] Verify green status dot pulses gently
- [ ] Confirm no scroll fade-in animations on any section

🤖 Generated with [Claude Code](https://claude.com/claude-code)